### PR TITLE
docs: Add project README and digit recognition testing guide

### DIFF
--- a/rust_bot_ng/README.md
+++ b/rust_bot_ng/README.md
@@ -1,0 +1,92 @@
+# RustBot-NG: A Game Bot in Rust
+
+## Overview
+
+RustBot-NG is a project to rewrite a Python-based game bot in Rust. The primary goals are to achieve better performance, explore potentially stealthier interaction techniques, and build a modern, robust architecture that can be extended with more advanced features, including AI capabilities.
+
+This bot interacts with games by reading screen information (visual perception) and emulating user input, primarily via an Arduino device for hardware-level input simulation.
+
+## Current Status (As of this document's last update)
+
+Core systems for input, screen perception, basic game logic, and configuration management are in place. A significant feature recently implemented is the ability to read HP (Health Points) and MP (Mana Points) directly from the screen using template-based digit recognition. The bot operates using a multi-threaded architecture, with separate threads for main gameplay logic (Cavebot), player status monitoring, and healing.
+
+## Key Features Implemented
+
+*   **Arduino-based Input Emulation**: All keyboard and mouse inputs are sent to an Arduino device, which then acts as a USB HID device. This is intended to provide a more hardware-like input pattern.
+*   **Screen Capture & Image Processing**:
+    *   Capture specific screen regions or the primary screen.
+    *   **Template Matching**: Locate predefined images (templates) on the screen (e.g., game objects, UI elements). Includes basic Non-Maximum Suppression.
+    *   **Digit Recognition**: Read numerical values (e.g., HP, MP) from the screen by recognizing sequences of digit templates.
+    *   **Caching**: Recently found template locations can be cached to improve performance.
+*   **Core Gameplay Logic**:
+    *   **GameContext**: A shared, thread-safe structure holding dynamic game state (player stats, bot settings) and control flags.
+    *   **Cavebot**: Manages waypoint-based navigation and task execution (e.g., walking, opening doors).
+    *   **PlayerMonitor**: Periodically reads player HP/MP from the screen and updates `GameContext`.
+    *   **Healer**: Checks player HP in `GameContext` and triggers a healing hotkey if HP is below a configured threshold.
+    *   **Tasks**: A system for defining and executing specific actions within the Cavebot (e.g., `WalkTask`, `OpenDoorTask`).
+*   **Configuration Management**:
+    *   Bot settings, hotkeys, Arduino configuration, and screen regions are loaded from a `config.toml` file using Serde.
+*   **Multi-threaded Architecture**: Key components like Cavebot, PlayerMonitor, and Healer run in separate threads for concurrent operation.
+
+## Module Overview (`src/`)
+
+The project is organized into several main modules:
+
+*   **`config`**: Handles loading and parsing of `config.toml` using Serde.
+    *   `settings.rs`: Defines the configuration structs (`Config`, `ScreenRegion`, etc.).
+*   **`input`**: Manages input emulation.
+    *   `arduino.rs`: Handles serial communication with the Arduino device.
+    *   `keyboard.rs`: Provides functions for keyboard actions (press, hotkey, write) via Arduino.
+    *   `mouse.rs`: Provides functions for mouse actions (move, click, drag, scroll) via Arduino.
+*   **`image_processing`**: Contains all logic related to analyzing screen captures.
+    *   `cache.rs`: Implements `DetectionCache` for storing locations of found templates.
+    *   `digit_recognition.rs`: Implements `recognize_digits_in_region` for reading numbers.
+    *   `matching.rs`: Provides `locate_template_on_image` and `locate_all_templates_on_image` for finding templates.
+    *   `templates.rs`: Implements `TemplateManager` for loading and managing image templates.
+*   **`screen_capture`**: Provides functions to capture images from the screen.
+    *   `capture.rs`: Implements screen and region capture utilities.
+*   **`game_logic`**: Contains the bot's decision-making and operational logic.
+    *   `cavebot/`: Manages waypoint navigation and task execution.
+        *   `core.rs`: `Cavebot` struct and main loop.
+        *   `tasks.rs`: `CavebotTask` enum and execution logic.
+        *   `waypoints.rs`: `Waypoint` and `WaypointType` definitions.
+    *   `context.rs`: Defines `GameContext`, `PlayerStats`, `BotSettings`.
+    *   `healer.rs`: Implements the `Healer` struct and its logic.
+    *   `player_monitor.rs`: Implements `PlayerMonitor` for tracking HP/MP.
+*   **`error.rs`** (or in `main.rs`): Defines the project's custom `AppError` enum for unified error handling.
+*   **`utils.rs`** (if present): For shared utility functions.
+*   **`main.rs`**: The application entry point, initializes all modules, sets up shared contexts, and spawns threads.
+
+## Configuration
+
+*   Primary configuration is done via `rust_bot_ng/config.toml`. This file defines Arduino port, hotkeys, screen regions for HP/MP, and other settings.
+*   Image templates (e.g., for digits, UI elements) are stored in `rust_bot_ng/templates/`.
+*   For detailed instructions on setting up test assets for digit recognition, see `TESTING_DIGIT_RECOGNITION.md`.
+
+## Building and Running (Conceptual)
+
+1.  **Dependencies**:
+    *   Rust (stable edition).
+    *   OpenCV development libraries.
+    *   A C++ toolchain (required by the OpenCV crate).
+    *   An Arduino device flashed with compatible firmware that understands the serial commands sent by this bot.
+2.  **Build**: Navigate to the `rust_bot_ng` project root and run `cargo build --release`.
+3.  **Configure**:
+    *   Set up `config.toml` with your specific game settings, Arduino port, hotkeys, and screen regions.
+    *   Place necessary image templates in the `templates/` directory, especially digit templates in `templates/digits/`.
+4.  **Run**: Execute the compiled binary from `target/release/`.
+
+## Next Steps & Future Work
+
+*   **Robust Perception**:
+    *   Thoroughly test and refine digit recognition with a comprehensive set of real game images.
+    *   Implement more advanced OCR for reading text (e.g., player names, chat messages) if needed.
+    *   Expand symbolic recognition for game icons, buffs, etc.
+*   **Expanded Game Logic**:
+    *   Implement more `CavebotTask` types for diverse actions (looting, targeting, spell casting).
+    *   Develop a more sophisticated targeting system.
+    *   Build Finite State Machines (FSMs) or Behavior Trees for more complex decision-making.
+*   **AI Integration**: Explore integrating machine learning models (e.g., for visual perception, decision making) using Rust's ML ecosystem (like `tch-rs`).
+*   **User Interface**: Develop a GUI for easier configuration, monitoring, and control of the bot.
+*   **Refinement**: Continuous performance optimization, error handling improvements, and code refactoring.
+```

--- a/rust_bot_ng/TESTING_DIGIT_RECOGNITION.md
+++ b/rust_bot_ng/TESTING_DIGIT_RECOGNITION.md
@@ -1,0 +1,106 @@
+# Testing Digit Recognition
+
+## Objective
+
+This document outlines the process and requirements for testing the image-based digit recognition functionality (`recognize_digits_in_region`) in the `rust_bot_ng` project. Accurate digit recognition is crucial for features like reading HP, MP, quantities, etc., from the game screen.
+
+## Required Test Assets
+
+To effectively test and refine the digit recognition, we need a set of image assets:
+
+### 1. Digit Templates
+
+These are individual image files for each digit (0 through 9).
+*   **Naming Convention**: `digit_0.png`, `digit_1.png`, ..., `digit_9.png`.
+*   **Location**: `rust_bot_ng/templates/digits/`
+*   **Specifications**:
+    *   Each image should contain only one digit.
+    *   Digits should be tightly cropped (minimal empty space around the digit).
+    *   They must accurately represent the font, size, and style of digits as they appear in the game UI elements you want to read.
+    *   Ensure consistent background color if possible, or use transparency if the digit rendering in-game supports it and templates are PNGs.
+    *   The current placeholder files in this directory must be replaced with these actual game assets.
+
+### 2. Test Images (Fixtures)
+
+These are sample screenshots of game UI elements that display numbers you intend to read (e.g., HP bars, MP bars, item counts).
+*   **Location**: `rust_bot_ng/tests/fixtures/digit_recognition/`
+    *   Create this directory if it doesn't exist.
+*   **Naming Convention**: Use descriptive names, e.g., `hp_100_max_150.png`, `mp_75_full.png`, `item_count_12.png`.
+*   **Specifications**:
+    *   Capture screenshots of various numbers and scenarios.
+    *   Include examples of minimum, maximum, and typical values.
+    *   If possible, include images where numbers might be close to other UI elements to test robustness.
+    *   Ensure these images are saved in a standard format (e.g., PNG).
+
+## Directory Structure
+
+The expected directory structure for these assets is:
+
+```
+rust_bot_ng/
+├── src/
+│   └── ... (project source code)
+├── templates/
+│   └── digits/         # <-- Your actual digit templates go here
+│       ├── digit_0.png
+│       ├── digit_1.png
+│       └── ...
+│       └── digit_9.png
+├── tests/
+│   └── fixtures/
+│       └── digit_recognition/  # <-- Your test images go here
+│           ├── hp_example_01.png
+│           ├── mp_example_01.png
+│           └── ... (other test images)
+└── TESTING_DIGIT_RECOGNITION.md # <-- This file
+└── ... (other project files like Cargo.toml, config.toml)
+```
+
+## Testing Procedure Outline
+
+The primary way to test is by expanding the unit tests in `src/image_processing/digit_recognition.rs`.
+
+1.  **Navigate to the Test Module**: Open `src/image_processing/digit_recognition.rs` and find the `#[cfg(test)] mod tests { ... }` section.
+2.  **Create or Modify Test Functions**:
+    *   You can modify the existing `test_recognize_simple_number()` or (preferably) create new, more specific test functions for each test image.
+    *   Example test function:
+        ```rust
+        #[test]
+        fn test_hp_reading_from_image_example_01() {
+            // 1. Setup: Initialize logger, TemplateManager
+            //    (Ensure TemplateManager loads from the correct `templates/` path)
+            //    let mut template_manager = TemplateManager::new();
+            //    // Adjust path as needed relative to where tests are run or use absolute/manifest-relative paths
+            //    template_manager.load_templates_from_directory("../../templates").expect("Failed to load templates");
+
+            // 2. Load Test Image (Fixture):
+            //    let test_image_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/digit_recognition/hp_example_01.png");
+            //    let region_image = image::open(test_image_path).expect("Failed to load test image: hp_example_01.png");
+
+            // 3. Call Recognition Function:
+            //    let recognized_value = recognize_digits_in_region(&region_image, &template_manager, "digit_");
+
+            // 4. Assert Expected Outcome:
+            //    // Assuming hp_example_01.png shows the number 123
+            //    assert_eq!(recognized_value.unwrap(), Some(123), "Failed to recognize HP as 123 from hp_example_01.png");
+        }
+        ```
+3.  **Run Tests**: Execute `cargo test` from the `rust_bot_ng` project root.
+4.  **Iterate**: If tests fail, examine the detailed logs produced by `recognize_digits_in_region`. You may need to:
+    *   Adjust the digit templates.
+    *   Tune parameters within `recognize_digits_in_region` (see below).
+    *   Verify the screen regions defined in `config.toml` if testing the full `PlayerMonitor` flow.
+
+## Key Tuning Parameters
+
+Within `src/image_processing/digit_recognition.rs`, the `recognize_digits_in_region` function's accuracy can be influenced by:
+
+*   **`confidence_threshold`**: (Inside `recognize_digits_in_region`, passed to `locate_all_templates_on_image`). If too high, faint or slightly different digits might be missed. If too low, false positives might occur.
+*   **`max_overlap`**: (Passed to `locate_all_templates_on_image`). Affects the simple Non-Maximum Suppression. If digits are very close, this might need tuning.
+*   **Quality of Digit Templates**: This is paramount. Templates must be clean and representative.
+*   **Image Preprocessing**: Currently, no specific preprocessing (like binarization or scaling) is done on the `region_image` before digit matching. If recognition is poor, such steps might need to be added to `recognize_digits_in_region` or applied to the source image before calling.
+
+## Contribution
+
+Please populate the `templates/digits/` and `tests/fixtures/digit_recognition/` directories with the high-quality assets described above. This will enable thorough testing and refinement of the bot's visual perception capabilities.
+```


### PR DESCRIPTION
This commit includes:

1.  A comprehensive `README.md` for the `rust_bot_ng` project. It details:
    *   Project overview, goals, and current status.
    *   Key implemented features (Arduino input, screen perception, core game logic, config, threading).
    *   An overview of the module structure in `src/`.
    *   Notes on configuration (`config.toml`) and image templates.
    *   Conceptual build and run instructions.
    *   Future development directions.

2.  `TESTING_DIGIT_RECOGNITION.md`: A guide outlining how to prepare test assets (digit templates, fixture images) and conduct unit tests for the image-based digit recognition functionality. It also highlights key parameters for tuning accuracy.