### PR TITLE
feat: Add core Wait, Say, and UseSelfItem tasks to Cavebot

### DIFF
--- a/rust_bot_ng/src/game_logic/cavebot/core.rs
+++ b/rust_bot_ng/src/game_logic/cavebot/core.rs
@@ -122,6 +122,23 @@ impl Cavebot {
                     };
                     task.execute(deps)
                 }
+                WaypointType::Wait { duration_ms } => {
+                    info!("Creating WaitTask for {} ms", duration_ms);
+                    let task = tasks::CavebotTask::Wait {
+                        duration: std::time::Duration::from_millis(duration_ms),
+                    };
+                    task.execute(deps)
+                }
+                WaypointType::Say { message } => {
+                    info!("Creating SayTask with message: '{}'", message);
+                    let task = tasks::CavebotTask::Say { message: message.clone() };
+                    task.execute(deps)
+                }
+                WaypointType::UseSelfItem { hotkey } => {
+                    info!("Creating UseSelfItemTask with hotkey: '{}'", hotkey);
+                    let task = tasks::CavebotTask::UseSelfItem { hotkey: hotkey.clone() };
+                    task.execute(deps)
+                }
                 // Add other WaypointType cases here
                 _ => {
                     warn!("Task execution for waypoint type '{:?}' not implemented yet.", waypoint.waypoint_type);

--- a/rust_bot_ng/src/game_logic/cavebot/waypoints.rs
+++ b/rust_bot_ng/src/game_logic/cavebot/waypoints.rs
@@ -9,8 +9,9 @@ pub enum WaypointType {
     Refill,     // Trigger a refilling sequence (potions, arrows)
     Approach,   // Approach a creature or specific point
     Target,     // Select a target (monster)
-    Wait,       // Pause execution for a specified duration
-    Say,        // Say something in chat (e.g. for spells or interacting with NPCs)
+    Wait { duration_ms: u64 }, // Pause execution for a specified duration
+    Say { message: String },    // Say something in chat (e.g. for spells or interacting with NPCs)
+    UseSelfItem { hotkey: String }, // Use an item on oneself via hotkey (e.g., potion, spell)
     Script,     // Execute a sub-script or a sequence of actions
     Logout,     // Log out of the game
     // TODO: Add other types as identified from Python's waypoint.py or taskList, e.g., Attack, SpecialAttack, DropLoot
@@ -21,12 +22,13 @@ pub struct Waypoint {
     pub label: String,
     pub waypoint_type: WaypointType,
     pub coordinate: (i32, i32, i32), // (x, y, z) representing game coordinates
+    pub duration_ms: Option<u64>, // For Wait type if not directly in enum, or for general use
+    pub message: Option<String>,     // For Say type
+    pub hotkey: Option<String>,      // For potential future hotkey-related tasks
     // TODO: Add other potential fields like metadata/options for specific types.
     // For example:
     // pub item_id: Option<u32>, // For Use, Pick, DropLoot
     // pub target_name: Option<String>, // For Target, Approach
-    // pub duration_ms: Option<u64>, // For Wait
-    // pub message: Option<String>, // For Say
     // pub script_name: Option<String>, // For Script
 }
 
@@ -40,7 +42,9 @@ impl Waypoint {
             label,
             waypoint_type,
             coordinate,
-            // Initialize other fields to None or default values here
+            duration_ms: None,
+            message: None,
+            hotkey: None,
         }
     }
 }

--- a/rust_bot_ng/src/main.rs
+++ b/rust_bot_ng/src/main.rs
@@ -184,11 +184,44 @@ fn main() -> Result<(), AppError> {
     let mut cavebot = Cavebot::new(Arc::clone(&game_context));
 
     // Add some dummy waypoints for testing
-    // cavebot.add_waypoint(Waypoint::new("Start".to_string(), WaypointType::Walk, (100, 200, 7)));
-    // cavebot.add_waypoint(Waypoint::new("Open a Door".to_string(), WaypointType::OpenDoor, (110, 200, 7))); // Test OpenDoor
-    // cavebot.add_waypoint(Waypoint::new("Use Ladder".to_string(), WaypointType::Use, (105, 200, 7)));
-    // cavebot.add_waypoint(Waypoint::new("Go to monsters".to_string(), WaypointType::Walk, (150, 250, 6)));
-    // info!("Cavebot initialized with {} waypoints.", cavebot.waypoints_count());
+    cavebot.add_waypoint(Waypoint::new("Start".to_string(), WaypointType::Walk, (100, 200, 7)));
+    cavebot.add_waypoint(Waypoint::new("Open a Door".to_string(), WaypointType::OpenDoor, (110, 200, 7)));
+    
+    // Example for Wait WaypointType
+    cavebot.add_waypoint(Waypoint {
+        label: "Short Pause".to_string(),
+        waypoint_type: WaypointType::Wait { duration_ms: 2000 }, // Wait for 2 seconds
+        coordinate: (0,0,0), // Coordinate might be irrelevant for Wait, use a placeholder
+        duration_ms: Some(2000), // Also set the optional field for consistency
+        message: None,
+        hotkey: None,
+    });
+
+    // Example for Say WaypointType
+    cavebot.add_waypoint(Waypoint {
+        label: "Greeting".to_string(),
+        waypoint_type: WaypointType::Say { message: "Hello from RustBot-NG!".to_string() },
+        coordinate: (0,0,0), // Coordinate irrelevant
+        duration_ms: None,
+        message: Some("Hello from RustBot-NG!".to_string()), // Optional field
+        hotkey: None,
+    });
+
+    // Example for UseSelfItem WaypointType
+    // Assumes "f2" is configured for a mana potion or similar self-use item in config.hotkeys if used elsewhere
+    // For this WaypointType, the hotkey comes directly from the WaypointType variant.
+    cavebot.add_waypoint(Waypoint {
+        label: "Use Mana Potion".to_string(),
+        waypoint_type: WaypointType::UseSelfItem { hotkey: "f2".to_string() }, // Example: "f2"
+        coordinate: (0,0,0), // Coordinate irrelevant
+        duration_ms: None,
+        message: None,
+        hotkey: Some("f2".to_string()), // Optional field for general reference, primary data in WaypointType
+    });
+
+    cavebot.add_waypoint(Waypoint::new("Use Ladder".to_string(), WaypointType::Use, (105, 200, 7))); // This will currently log "not implemented"
+    cavebot.add_waypoint(Waypoint::new("Go to monsters".to_string(), WaypointType::Walk, (150, 250, 6)));
+    info!("Cavebot initialized with {} waypoints.", cavebot.waypoints_count());
 
     // Initialize Arc for config to share with AllDependencies
     let config_arc = Arc::new(config);


### PR DESCRIPTION
This commit expands the Cavebot's capabilities by adding three fundamental task types:

1.  **Wait Task**:
    *   Introduces `WaypointType::Wait { duration_ms: u64 }` and `CavebotTask::Wait { duration: Duration }`.
    *   Allows the bot to pause execution for a specified duration during a waypoint script.
    *   The `Waypoint` struct has been updated with optional fields (`duration_ms`, `message`, `hotkey`) to accommodate parameters for various task types.

2.  **Say Task**:
    *   Introduces `WaypointType::Say { message: String }` and `CavebotTask::Say { message: String }`.
    *   Enables the bot to type chat messages or commands using `input::keyboard::write` via the Arduino.

3.  **UseSelfItem Task**:
    *   Introduces `WaypointType::UseSelfItem { hotkey: String }` and `CavebotTask::UseSelfItem { hotkey: String }`.
    *   Allows the bot to press a specified hotkey, typically for using an item on the player character (e.g., potions, runes).

These tasks are integrated into the `Cavebot::run_main_loop` and example usage has been added to `main.rs`. This provides greater flexibility for creating waypoint scripts.