### PR TITLE
refactor: Update project name to SKB in docs and Cargo

### DIFF
--- a/rust_bot_ng/Cargo.toml
+++ b/rust_bot_ng/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust_bot_ng"
+name = "skb"
 version = "0.1.0"
 edition = "2021"
 

--- a/rust_bot_ng/README.md
+++ b/rust_bot_ng/README.md
@@ -1,8 +1,8 @@
-# RustBot-NG: A Game Bot in Rust
+# SKB: A Game Bot in Rust
 
 ## Overview
 
-RustBot-NG is a project to rewrite a Python-based game bot in Rust. The primary goals are to achieve better performance, explore potentially stealthier interaction techniques, and build a modern, robust architecture that can be extended with more advanced features, including AI capabilities.
+SKB is a project to rewrite a Python-based game bot in Rust. The primary goals are to achieve better performance, explore potentially stealthier interaction techniques, and build a modern, robust architecture that can be extended with more advanced features, including AI capabilities.
 
 This bot interacts with games by reading screen information (visual perception) and emulating user input, primarily via an Arduino device for hardware-level input simulation.
 
@@ -70,7 +70,7 @@ The project is organized into several main modules:
     *   OpenCV development libraries.
     *   A C++ toolchain (required by the OpenCV crate).
     *   An Arduino device flashed with compatible firmware that understands the serial commands sent by this bot.
-2.  **Build**: Navigate to the `rust_bot_ng` project root and run `cargo build --release`.
+2.  **Build**: Navigate to the SKB project root and run `cargo build --release`.
 3.  **Configure**:
     *   Set up `config.toml` with your specific game settings, Arduino port, hotkeys, and screen regions.
     *   Place necessary image templates in the `templates/` directory, especially digit templates in `templates/digits/`.

--- a/rust_bot_ng/TESTING_DIGIT_RECOGNITION.md
+++ b/rust_bot_ng/TESTING_DIGIT_RECOGNITION.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-This document outlines the process and requirements for testing the image-based digit recognition functionality (`recognize_digits_in_region`) in the `rust_bot_ng` project. Accurate digit recognition is crucial for features like reading HP, MP, quantities, etc., from the game screen.
+This document outlines the process and requirements for testing the image-based digit recognition functionality (`recognize_digits_in_region`) in the `SKB` project. Accurate digit recognition is crucial for features like reading HP, MP, quantities, etc., from the game screen.
 
 ## Required Test Assets
 

--- a/rust_bot_ng/src/main.rs
+++ b/rust_bot_ng/src/main.rs
@@ -137,10 +137,10 @@ fn main() -> Result<(), AppError> {
     // Initialize TemplateManager and load templates
     // TemplateManager::load_templates_from_directory will recursively load from subdirectories like "templates/digits/"
     let mut template_manager = TemplateManager::new();
-    match template_manager.load_templates_from_directory("rust_bot_ng/templates") {
-        Ok(_) => info!("Templates loaded successfully from rust_bot_ng/templates/ (including subdirectories like digits/ if present)."),
+    match template_manager.load_templates_from_directory("templates") { // Changed path to relative
+        Ok(_) => info!("Templates loaded successfully from templates/ (including subdirectories like digits/ if present)."),
         Err(e) => {
-            error!("Failed to load templates from rust_bot_ng/templates/: {}. Proceeding with empty TemplateManager.", e);
+            error!("Failed to load templates from templates/: {}. Proceeding with empty TemplateManager.", e);
             // This might be acceptable if templates are optional or only for specific features.
         }
     }


### PR DESCRIPTION
This commit applies textual and configuration changes to reflect the project's name change from "RustBot-NG" to "SKB".

Changes include:

*   **Cargo.toml**: The package name in `rust_bot_ng/Cargo.toml` has been updated from `rust_bot_ng` to `skb`.
*   **README.md**: Textual references to "RustBot-NG" as the project name have been updated to "SKB".
*   **TESTING_DIGIT_RECOGNITION.md**: Prose references like "`rust_bot_ng` project" have been updated to "`SKB` project".
*   **main.rs**: Paths for loading `templates/` and `config.toml` have been made relative, removing the hardcoded "rust_bot_ng" directory prefix from these strings.

The physical project directory `rust_bot_ng/` has not been renamed in this commit. This set of changes primarily addresses the project's identity in documentation and its Cargo package configuration.