### PR TITLE
feat: Migrate skills module to Rust

### DIFF
--- a/py_rust_utils/Cargo.lock
+++ b/py_rust_utils/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "farmhash"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ce9c8fb9891c75ceadbc330752951a4e369b50af10775955aeb9af3eee34b"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,12 +55,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "numpy"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec170733ca37175f5d75a5bea5911d6ff45d2cd52849ce98b685394e4f2f37f4"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -105,6 +176,8 @@ dependencies = [
 name = "py_rust_utils"
 version = "0.1.0"
 dependencies = [
+ "farmhash",
+ "numpy",
  "pyo3",
 ]
 
@@ -181,6 +254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +267,12 @@ checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "scopeguard"

--- a/py_rust_utils/Cargo.toml
+++ b/py_rust_utils/Cargo.toml
@@ -11,3 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.21.0", features = ["extension-module", "auto-initialize"] }
+numpy = "0.21.0"
+farmhash = "1.1.1"

--- a/py_rust_utils/src/lib.rs
+++ b/py_rust_utils/src/lib.rs
@@ -1,5 +1,11 @@
 use pyo3::prelude::*;
+use numpy::PyReadonlyArray2;
+use numpy::ndarray::{ArrayView, Ix2}; 
+use std::collections::HashMap;
+use farmhash::FarmHasher;
+use std::hash::Hasher;
 
+// --- Existing Functions ---
 #[pyfunction]
 fn coordinates_are_equal(first_coordinate: (i32, i32, i32), second_coordinate: (i32, i32, i32)) -> bool {
     first_coordinate == second_coordinate
@@ -8,71 +14,371 @@ fn coordinates_are_equal(first_coordinate: (i32, i32, i32), second_coordinate: (
 #[pyfunction]
 fn release_keys(_py: Python, last_pressed_key: Option<String>) -> PyResult<Option<String>> {
     if let Some(key) = last_pressed_key {
-        // In this isolated crate, we cannot easily call into the main bot's Rust input module.
-        // This will be a placeholder. The Python side will still handle the actual keyUp.
-        // OR, if direct system key-up is desired here, a crate like 'enigo' could be added.
-        // For now, keeping it simple:
         println!("Rust (py_rust_utils): 'keyUp({})' action placeholder. Actual key release should be handled by Python or a dedicated input crate.", key);
     }
-    // Python's original logic was: context['ng_lastPressedKey'] = None
-    // So we return Ok(None) to signify this.
     Ok(None)
 }
 
+// --- New Helper Functions ---
+fn extract_and_process_region(
+    screenshot_view: &ArrayView<u8, Ix2>, 
+    region_x: usize, region_y: usize, region_width: usize, region_height: usize,
+    apply_value_filter: bool,
+) -> Option<Vec<u8>> {
+    if region_width == 0 || region_height == 0 { 
+        return None;
+    }
+    if region_y.saturating_add(region_height) > screenshot_view.shape()[0] || 
+       region_x.saturating_add(region_width) > screenshot_view.shape()[1] ||
+       region_y >= screenshot_view.shape()[0] || region_x >= screenshot_view.shape()[1] {
+        return None; 
+    }
+
+    let mut processed_data = Vec::with_capacity(region_width * region_height);
+    for r in 0..region_height {
+        for c in 0..region_width {
+            let val = screenshot_view[(region_y + r, region_x + c)];
+            let mut processed_val = val;
+            
+            if val >= 50 && val <= 100 { 
+                processed_val = 0;
+            }
+            
+            if apply_value_filter { 
+                if processed_val == 126 || processed_val == 192 {
+                    processed_val = 192;
+                } else if processed_val != 192 { 
+                    processed_val = 0;
+                }
+            }
+            processed_data.push(processed_val);
+        }
+    }
+    Some(processed_data)
+}
+
+fn hashit_rust(data: &[u8]) -> i64 {
+    let mut hasher = FarmHasher::default();
+    hasher.write(data);
+    hasher.finish() as i64 
+}
+
+fn get_hashed_value(
+    screenshot_view: &ArrayView<u8, Ix2>, 
+    base_x: i32, 
+    base_y: i32, 
+    img_slice_x_offset: i32, 
+    img_slice_width: usize, 
+    img_slice_height: usize, 
+    hashes_map: &HashMap<i64, i32>,
+    is_value_type: bool,
+) -> i32 {
+    let final_x = base_x.saturating_add(img_slice_x_offset);
+    let final_y = base_y;
+
+    if final_x < 0 || final_y < 0 {
+        return 0; 
+    }
+
+    let region_data = extract_and_process_region(
+        screenshot_view,
+        final_x as usize,
+        final_y as usize,
+        img_slice_width,
+        img_slice_height,
+        is_value_type,
+    );
+
+    if let Some(data) = region_data {
+        if data.is_empty() { 
+            return 0;
+        }
+        let hash = hashit_rust(&data);
+        *hashes_map.get(&hash).unwrap_or(&0)
+    } else {
+        0 
+    }
+}
+
+// --- New FFI Functions ---
+#[pyfunction]
+#[pyo3(signature = (screenshot, skills_icon_bbox, numbers_hashes))]
+fn get_hp_rust(
+    screenshot: PyReadonlyArray2<u8>,
+    skills_icon_bbox: Option<(i32, i32, i32, i32)>, 
+    numbers_hashes: HashMap<i64, i32>,
+) -> PyResult<Option<i32>> {
+    if skills_icon_bbox.is_none() {
+        return Ok(None);
+    }
+    let bbox = skills_icon_bbox.unwrap();
+    let icon_x = bbox.0;
+    let icon_y = bbox.1;
+
+    let base_x = icon_x + 6;
+    let base_y = icon_y + 90;
+    let screenshot_view = screenshot.as_array(); 
+
+    let hundreds_val = get_hashed_value(&screenshot_view, base_x, base_y, 122, 22, 8, &numbers_hashes, true);
+    let thousands_val = get_hashed_value(&screenshot_view, base_x, base_y, 94, 22, 8, &numbers_hashes, true);
+    
+    Ok(Some((thousands_val * 1000) + hundreds_val))
+}
+
+#[pyfunction]
+#[pyo3(signature = (screenshot, skills_icon_bbox, numbers_hashes))]
+fn get_mana_rust(
+    screenshot: PyReadonlyArray2<u8>,
+    skills_icon_bbox: Option<(i32, i32, i32, i32)>,
+    numbers_hashes: HashMap<i64, i32>,
+) -> PyResult<Option<i32>> {
+    if skills_icon_bbox.is_none() { return Ok(None); }
+    let bbox = skills_icon_bbox.unwrap();
+    let base_x = bbox.0 + 6;
+    let base_y = bbox.1 + 104; 
+    let screenshot_view = screenshot.as_array();
+    let hundreds_val = get_hashed_value(&screenshot_view, base_x, base_y, 122, 22, 8, &numbers_hashes, true);
+    let thousands_val = get_hashed_value(&screenshot_view, base_x, base_y, 94, 22, 8, &numbers_hashes, true);
+    Ok(Some((thousands_val * 1000) + hundreds_val))
+}
+
+#[pyfunction]
+#[pyo3(signature = (screenshot, skills_icon_bbox, numbers_hashes))]
+fn get_capacity_rust(
+    screenshot: PyReadonlyArray2<u8>,
+    skills_icon_bbox: Option<(i32, i32, i32, i32)>,
+    numbers_hashes: HashMap<i64, i32>,
+) -> PyResult<Option<i32>> {
+    if skills_icon_bbox.is_none() { return Ok(None); }
+    let bbox = skills_icon_bbox.unwrap();
+    let base_x = bbox.0 + 6;
+    let base_y = bbox.1 + 132; 
+    let screenshot_view = screenshot.as_array();
+    let hundreds_val = get_hashed_value(&screenshot_view, base_x, base_y, 122, 22, 8, &numbers_hashes, true);
+    let thousands_val = get_hashed_value(&screenshot_view, base_x, base_y, 94, 22, 8, &numbers_hashes, true);
+    Ok(Some((thousands_val * 1000) + hundreds_val))
+}
+   
+#[pyfunction]
+#[pyo3(signature = (screenshot, skills_icon_bbox, numbers_hashes))]
+fn get_speed_rust(
+    screenshot: PyReadonlyArray2<u8>,
+    skills_icon_bbox: Option<(i32, i32, i32, i32)>,
+    numbers_hashes: HashMap<i64, i32>,
+) -> PyResult<Option<i32>> {
+    if skills_icon_bbox.is_none() { return Ok(None); }
+    let bbox = skills_icon_bbox.unwrap();
+    let base_x = bbox.0 + 6;
+    let base_y = bbox.1 + 146; 
+    let screenshot_view = screenshot.as_array();
+    let hundreds_val = get_hashed_value(&screenshot_view, base_x, base_y, 122, 22, 8, &numbers_hashes, true);
+    let thousands_val = get_hashed_value(&screenshot_view, base_x, base_y, 94, 22, 8, &numbers_hashes, true);
+    Ok(Some((thousands_val * 1000) + hundreds_val))
+}
+
+#[pyfunction]
+#[pyo3(signature = (screenshot, skills_icon_bbox, minutes_or_hours_hashes))]
+fn get_food_rust(
+    screenshot: PyReadonlyArray2<u8>,
+    skills_icon_bbox: Option<(i32, i32, i32, i32)>,
+    minutes_or_hours_hashes: HashMap<i64, i32>,
+) -> PyResult<Option<i32>> {
+    if skills_icon_bbox.is_none() { return Ok(None); }
+    let bbox = skills_icon_bbox.unwrap();
+    let base_x = bbox.0 + 6;
+    let base_y = bbox.1 + 160; 
+    let screenshot_view = screenshot.as_array();
+    let minutes_val = get_hashed_value(&screenshot_view, base_x, base_y, 130, 14, 8, &minutes_or_hours_hashes, false);
+    let hours_val = get_hashed_value(&screenshot_view, base_x, base_y, 110, 14, 8, &minutes_or_hours_hashes, false);
+    Ok(Some((hours_val * 60) + minutes_val))
+}
+
+#[pyfunction]
+#[pyo3(signature = (screenshot, skills_icon_bbox, minutes_or_hours_hashes))]
+fn get_stamina_rust(
+    screenshot: PyReadonlyArray2<u8>,
+    skills_icon_bbox: Option<(i32, i32, i32, i32)>,
+    minutes_or_hours_hashes: HashMap<i64, i32>,
+) -> PyResult<Option<i32>> {
+    if skills_icon_bbox.is_none() { return Ok(None); }
+    let bbox = skills_icon_bbox.unwrap();
+    let base_x = bbox.0 + 6;
+    let base_y = bbox.1 + 174; 
+    let screenshot_view = screenshot.as_array();
+    let minutes_val = get_hashed_value(&screenshot_view, base_x, base_y, 130, 14, 8, &minutes_or_hours_hashes, false);
+    let hours_val = get_hashed_value(&screenshot_view, base_x, base_y, 110, 14, 8, &minutes_or_hours_hashes, false);
+    Ok(Some((hours_val * 60) + minutes_val))
+}
+   
+// --- Updated PyModule ---
 #[pymodule]
-#[pyo3(name = "py_rust_utils_module")] // Explicitly name the Python module
+#[pyo3(name = "py_rust_utils_module")] 
 fn rust_utils_module(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(coordinates_are_equal, m)?)?;
     m.add_function(wrap_pyfunction!(release_keys, m)?)?;
+    m.add_function(wrap_pyfunction!(get_hp_rust, m)?)?;
+    m.add_function(wrap_pyfunction!(get_mana_rust, m)?)?;
+    m.add_function(wrap_pyfunction!(get_capacity_rust, m)?)?;
+    m.add_function(wrap_pyfunction!(get_speed_rust, m)?)?;
+    m.add_function(wrap_pyfunction!(get_food_rust, m)?)?;
+    m.add_function(wrap_pyfunction!(get_stamina_rust, m)?)?;
     Ok(())
 }
 
+// --- Tests ---
 #[cfg(test)]
 mod tests {
     use super::*;
-    //use pyo3::types::PyAny; // Required for with_gil. Not strictly required for these tests as Python::with_gil is used.
+    use numpy::{PyArray, PyArrayMethods}; // Added PyArrayMethods
+    use numpy::ndarray::Array; 
 
-    #[test]
-    fn test_coordinates_are_equal_positive() {
-        assert!(coordinates_are_equal((1, 2, 3), (1, 2, 3)));
+    fn get_reference_hash(data: &[u8]) -> i64 {
+        let mut hasher = FarmHasher::default();
+        hasher.write(data);
+        hasher.finish() as i64
     }
 
-    #[test]
-    fn test_coordinates_are_equal_negative_x() {
-        assert!(!coordinates_are_equal((0, 2, 3), (1, 2, 3)));
-    }
-
-    #[test]
-    fn test_coordinates_are_equal_negative_y() {
-        assert!(!coordinates_are_equal((1, 0, 3), (1, 2, 3)));
-    }
-
-    #[test]
-    fn test_coordinates_are_equal_negative_z() {
-        assert!(!coordinates_are_equal((1, 2, 0), (1, 2, 3)));
+    // Corrected signature and usage for create_mock_screenshot_array
+    fn create_mock_screenshot_array<'a>(py: Python<'a>, data: &'a [u8], rows: usize, cols: usize) -> PyReadonlyArray2<'a, u8> {
+        PyArray::from_slice_bound(py, data) 
+            .reshape((rows, cols)).unwrap()
+            .readonly()
     }
     
-    #[test]
-    fn test_coordinates_are_equal_all_different() {
-        assert!(!coordinates_are_equal((0, 0, 0), (1, 2, 3)));
+    fn get_mock_numbers_hashes() -> HashMap<i64, i32> {
+        let mut hashes = HashMap::new();
+        let data_192_22x8 = vec![192u8; 22 * 8];
+        hashes.insert(get_reference_hash(&data_192_22x8), 1); 
+        let data_0_22x8 = vec![0u8; 22 * 8];
+        hashes.insert(get_reference_hash(&data_0_22x8), 0); 
+        let mut data_5_22x8 = vec![0u8; 22 * 8];
+        for i in 0..(22*8) { if i % 2 == 0 { data_5_22x8[i] = 192; } } 
+        hashes.insert(get_reference_hash(&data_5_22x8), 5);
+        hashes
+    }
+
+    fn get_mock_minutes_hours_hashes() -> HashMap<i64, i32> {
+        let mut hashes = HashMap::new();
+        let data_0_14x8 = vec![0u8; 14 * 8];
+        hashes.insert(get_reference_hash(&data_0_14x8), 0); 
+        let mut data_3_14x8 = vec![0u8; 14*8];
+        for i in 0..(14*8) { if i % 3 == 0 { data_3_14x8[i] = 120; } } 
+        hashes.insert(get_reference_hash(&data_3_14x8), 3);
+        hashes
     }
 
     #[test]
-    fn test_release_keys_with_some_key() {
-        // PyO3 functions that take Python<'_> argument need a GIL token
-        Python::with_gil(|py| {
-            let result = release_keys(py, Some("test_key".to_string()));
-            assert!(result.is_ok());
-            assert_eq!(result.unwrap(), None);
-        });
+    fn test_extract_and_process_region_normal() {
+        let data = Array::from_shape_vec((2, 3), vec![10u8, 60, 120, 20, 70, 130]).unwrap();
+        let view = data.view();
+        let result = extract_and_process_region(&view, 0, 0, 3, 2, false).unwrap();
+        assert_eq!(result, vec![10u8, 0, 120, 20, 0, 130]);
     }
 
     #[test]
-    fn test_release_keys_with_none_key() {
+    fn test_extract_and_process_region_filtered() {
+        let data = Array::from_shape_vec((2, 3), vec![10u8, 126, 192, 20, 70, 130]).unwrap();
+        let view = data.view();
+        let result = extract_and_process_region(&view, 0, 0, 3, 2, true).unwrap();
+        assert_eq!(result, vec![0u8, 192, 192, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_extract_and_process_region_out_of_bounds() {
+        let data = Array::from_shape_vec((2, 2), vec![1u8, 2, 3, 4]).unwrap();
+        let view = data.view();
+        assert!(extract_and_process_region(&view, 0, 0, 3, 2, false).is_none()); 
+        assert!(extract_and_process_region(&view, 0, 0, 2, 3, false).is_none()); 
+        assert!(extract_and_process_region(&view, 1, 1, 2, 2, false).is_none()); 
+        assert!(extract_and_process_region(&view, 2, 0, 1, 1, false).is_none()); 
+        assert!(extract_and_process_region(&view, 0, 2, 1, 1, false).is_none()); 
+        assert!(extract_and_process_region(&view, 0, 0, 0, 1, false).is_none()); 
+    }
+
+    #[test]
+    fn test_hashit_rust_known_value() {
+        let data: &[u8] = &[0, 1, 2, 3, 4, 5];
+        assert_eq!(hashit_rust(data), 2645327907902100037i64);
+    }
+
+    #[test]
+    fn test_get_hashed_value_logic() {
+        let screenshot_data = vec![70u8; 10 * 10];
+        let screenshot_arr = Array::from_shape_vec((10,10), screenshot_data).unwrap();
+        let screenshot_view = screenshot_arr.view();
+
+        let mut hashes = HashMap::new();
+        let all_zeros_2x2 = vec![0u8; 2 * 2];
+        let expected_hash = get_reference_hash(&all_zeros_2x2);
+        hashes.insert(expected_hash, 99);
+
+        let val = get_hashed_value(&screenshot_view, 0, 0, 0, 2, 2, &hashes, false);
+        assert_eq!(val, 99);
+        
+        let mut other_hashes = HashMap::new();
+        other_hashes.insert(12345, 10); 
+        let val_other_map = get_hashed_value(&screenshot_view, 0, 0, 0, 2, 2, &other_hashes, false);
+        assert_eq!(val_other_map, 0);
+
+        let val_oob = get_hashed_value(&screenshot_view, 0, 0, 0, 20, 20, &hashes, false);
+        assert_eq!(val_oob, 0);
+    }
+    
+    fn create_targeted_screenshot_data(val_for_thousands: u8, val_for_hundreds: u8, width: usize, height: usize) -> Vec<u8> {
+        let mut data = vec![150u8; width * height]; 
+        let base_x = 50 + 6; 
+        let base_y_hp = 50 + 90; 
+
+        let thousands_x_start = base_x + 94;
+        for r in 0..8 {
+            for c in 0..22 {
+                if (base_y_hp + r) < height && (thousands_x_start + c) < width { 
+                    data[(base_y_hp + r) * width + (thousands_x_start + c)] = val_for_thousands;
+                }
+            }
+        }
+        let hundreds_x_start = base_x + 122;
+         for r in 0..8 {
+            for c in 0..22 {
+                 if (base_y_hp + r) < height && (hundreds_x_start + c) < width { 
+                    data[(base_y_hp + r) * width + (hundreds_x_start + c)] = val_for_hundreds;
+                }
+            }
+        }
+        data
+    }
+
+    #[test]
+    fn test_get_hp_rust_specific_val() {
         Python::with_gil(|py| {
-            let result = release_keys(py, None);
-            assert!(result.is_ok());
-            assert_eq!(result.unwrap(), None);
+            let screenshot_data = create_targeted_screenshot_data(70, 126, 300, 300); 
+            let screenshot = create_mock_screenshot_array(py, &screenshot_data, 300, 300);
+            let mock_bbox = Some((50, 50, 160, 200)); 
+
+            let mut numbers_hashes = HashMap::new();
+            let data_all_zeros_22x8 = vec![0u8; 22 * 8];
+            let data_all_192s_22x8 = vec![192u8; 22 * 8];
+            numbers_hashes.insert(get_reference_hash(&data_all_zeros_22x8), 0); 
+            numbers_hashes.insert(get_reference_hash(&data_all_192s_22x8), 1); 
+            
+            let result = get_hp_rust(screenshot, mock_bbox, numbers_hashes).unwrap();
+            assert_eq!(result, Some(1)); 
         });
     }
+    
+    #[test] fn test_get_hp_rust_no_bbox() { Python::with_gil(|py| { assert_eq!(get_hp_rust(create_mock_screenshot_array(py, &[0u8;100],10,10), None, HashMap::new()).unwrap(), None); }); }
+    #[test] fn test_get_mana_rust_no_bbox() { Python::with_gil(|py| { assert_eq!(get_mana_rust(create_mock_screenshot_array(py, &[0u8;100],10,10), None, HashMap::new()).unwrap(), None); }); }
+    #[test] fn test_get_capacity_rust_no_bbox() { Python::with_gil(|py| { assert_eq!(get_capacity_rust(create_mock_screenshot_array(py, &[0u8;100],10,10), None, HashMap::new()).unwrap(), None); }); }
+    #[test] fn test_get_speed_rust_no_bbox() { Python::with_gil(|py| { assert_eq!(get_speed_rust(create_mock_screenshot_array(py, &[0u8;100],10,10), None, HashMap::new()).unwrap(), None); }); }
+    #[test] fn test_get_food_rust_no_bbox() { Python::with_gil(|py| { assert_eq!(get_food_rust(create_mock_screenshot_array(py, &[0u8;100],10,10), None, HashMap::new()).unwrap(), None); }); }
+    #[test] fn test_get_stamina_rust_no_bbox() { Python::with_gil(|py| { assert_eq!(get_stamina_rust(create_mock_screenshot_array(py, &[0u8;100],10,10), None, HashMap::new()).unwrap(), None); }); }
+
+    // --- Existing Tests (coordinates_are_equal, release_keys) ---
+    #[test] fn test_coordinates_are_equal_positive() { assert!(coordinates_are_equal((1, 2, 3), (1, 2, 3))); }
+    #[test] fn test_coordinates_are_equal_negative_x() { assert!(!coordinates_are_equal((0, 2, 3), (1, 2, 3))); }
+    #[test] fn test_coordinates_are_equal_negative_y() { assert!(!coordinates_are_equal((1, 0, 3), (1, 2, 3))); }
+    #[test] fn test_coordinates_are_equal_negative_z() { assert!(!coordinates_are_equal((1, 2, 0), (1, 2, 3))); }
+    #[test] fn test_coordinates_are_equal_all_different() { assert!(!coordinates_are_equal((0, 0, 0), (1, 2, 3))); }
+    #[test] fn test_release_keys_with_some_key() { Python::with_gil(|py| { let result = release_keys(py, Some("test_key".to_string())); assert!(result.is_ok()); assert_eq!(result.unwrap(), None); }); }
+    #[test] fn test_release_keys_with_none_key() { Python::with_gil(|py| { let result = release_keys(py, None); assert!(result.is_ok()); assert_eq!(result.unwrap(), None); }); }
 }

--- a/src/repositories/skills/core.py
+++ b/src/repositories/skills/core.py
@@ -1,118 +1,93 @@
 import numpy as np
 from typing import Union
 from src.shared.typings import BBox, GrayImage
-from src.utils.core import hashit
-from src.utils.image import convertGraysToBlack
+# Removed: from src.utils.core import hashit
+# Removed: from src.utils.image import convertGraysToBlack
 from .config import minutesOrHoursHashes, numbersHashes
 from .locators import getSkillsIconPosition
 
-
-# TODO: add unit tests
-# PERF: [0.04747469999999998, 2.9300000000009874e-05]
-def getCapacity(screenshot: GrayImage) -> Union[int, None]:
-    skillsIconPosition = getSkillsIconPosition(screenshot)
-    if skillsIconPosition is None:
-        return None
-    position = skillsIconPosition[0] + 6, skillsIconPosition[1] + \
-        132, skillsIconPosition[2], skillsIconPosition[3]
-    return getValuesCount(screenshot, position)
-
-
-# TODO: add unit tests
-# TODO: add perf
-def getFood(screenshot: GrayImage) -> Union[int, None]:
-    skillsIconPosition = getSkillsIconPosition(screenshot)
-    if skillsIconPosition is None:
-        return None
-    position = skillsIconPosition[0] + 6, skillsIconPosition[1] + \
-        160, skillsIconPosition[2], skillsIconPosition[3]
-    return getMinutesCount(screenshot, position)
+RUST_SKILL_FUNCTIONS_LOADED = False
+try:
+    from gameplay.py_rust_utils_module import (
+        get_hp_rust,
+        get_mana_rust,
+        get_capacity_rust,
+        get_speed_rust,
+        get_food_rust,
+        get_stamina_rust
+    )
+    RUST_SKILL_FUNCTIONS_LOADED = True
+    # print("Successfully loaded Rust skill extraction functions.")
+except ImportError as e:
+    print(f"Could not import Rust skill functions: {e}. Falling back to Python or raising error.")
+    # Depending on desired behavior, can raise error or have Python fallbacks.
+    # For this task, the functions below will raise if not loaded.
 
 
-# TODO: add unit tests
-# PERF: [0.04967209999999955, 3.1599999999798456e-05]
 def getHp(screenshot: GrayImage) -> Union[int, None]:
+    if not RUST_SKILL_FUNCTIONS_LOADED:
+        raise ImportError("Rust skill functions not loaded. Cannot get HP.")
     skillsIconPosition = getSkillsIconPosition(screenshot)
     if skillsIconPosition is None:
         return None
-    position = skillsIconPosition[0] + 6, skillsIconPosition[1] + \
-        90, skillsIconPosition[2], skillsIconPosition[3]
-    return getValuesCount(screenshot, position)
+    # Ensure screenshot is np.ndarray of np.uint8
+    if not isinstance(screenshot, np.ndarray) or screenshot.dtype != np.uint8:
+        screenshot = np.array(screenshot, dtype=np.uint8)
+    return get_hp_rust(screenshot, skillsIconPosition, numbersHashes)
 
 
-# TODO: add unit tests
-# PERF: [0.05254219999999998, 2.970000000068751e-05]
 def getMana(screenshot: GrayImage) -> Union[int, None]:
+    if not RUST_SKILL_FUNCTIONS_LOADED:
+        raise ImportError("Rust skill functions not loaded. Cannot get Mana.")
     skillsIconPosition = getSkillsIconPosition(screenshot)
     if skillsIconPosition is None:
         return None
-    position = skillsIconPosition[0] + 6, skillsIconPosition[1] + \
-        104, skillsIconPosition[2], skillsIconPosition[3]
-    return getValuesCount(screenshot, position)
+    if not isinstance(screenshot, np.ndarray) or screenshot.dtype != np.uint8:
+        screenshot = np.array(screenshot, dtype=np.uint8)
+    return get_mana_rust(screenshot, skillsIconPosition, numbersHashes)
 
 
-# TODO: add unit tests
-# PERF: [0.04700700000000024, 3.0399999999985994e-05]
+def getCapacity(screenshot: GrayImage) -> Union[int, None]:
+    if not RUST_SKILL_FUNCTIONS_LOADED:
+        raise ImportError("Rust skill functions not loaded. Cannot get Capacity.")
+    skillsIconPosition = getSkillsIconPosition(screenshot)
+    if skillsIconPosition is None:
+        return None
+    if not isinstance(screenshot, np.ndarray) or screenshot.dtype != np.uint8:
+        screenshot = np.array(screenshot, dtype=np.uint8)
+    return get_capacity_rust(screenshot, skillsIconPosition, numbersHashes)
+
+
 def getSpeed(screenshot: GrayImage) -> Union[int, None]:
+    if not RUST_SKILL_FUNCTIONS_LOADED:
+        raise ImportError("Rust skill functions not loaded. Cannot get Speed.")
     skillsIconPosition = getSkillsIconPosition(screenshot)
     if skillsIconPosition is None:
         return None
-    position = skillsIconPosition[0] + 6, skillsIconPosition[1] + \
-        146, skillsIconPosition[2], skillsIconPosition[3]
-    return getValuesCount(screenshot, position)
+    if not isinstance(screenshot, np.ndarray) or screenshot.dtype != np.uint8:
+        screenshot = np.array(screenshot, dtype=np.uint8)
+    return get_speed_rust(screenshot, skillsIconPosition, numbersHashes)
 
 
-# TODO: add unit tests
-# PERF: [0.047493200000000346, 2.0000000000131024e-05]
+def getFood(screenshot: GrayImage) -> Union[int, None]:
+    if not RUST_SKILL_FUNCTIONS_LOADED:
+        raise ImportError("Rust skill functions not loaded. Cannot get Food.")
+    skillsIconPosition = getSkillsIconPosition(screenshot)
+    if skillsIconPosition is None:
+        return None
+    if not isinstance(screenshot, np.ndarray) or screenshot.dtype != np.uint8:
+        screenshot = np.array(screenshot, dtype=np.uint8)
+    return get_food_rust(screenshot, skillsIconPosition, minutesOrHoursHashes)
+
+
 def getStamina(screenshot: GrayImage) -> Union[int, None]:
+    if not RUST_SKILL_FUNCTIONS_LOADED:
+        raise ImportError("Rust skill functions not loaded. Cannot get Stamina.")
     skillsIconPosition = getSkillsIconPosition(screenshot)
     if skillsIconPosition is None:
         return None
-    position = (skillsIconPosition[0] + 6), (skillsIconPosition[1] +
-                                            174), skillsIconPosition[2], skillsIconPosition[3]
-    return getMinutesCount(screenshot, position)
+    if not isinstance(screenshot, np.ndarray) or screenshot.dtype != np.uint8:
+        screenshot = np.array(screenshot, dtype=np.uint8)
+    return get_stamina_rust(screenshot, skillsIconPosition, minutesOrHoursHashes)
 
-
-# TODO: add unit tests
-# TODO: add perf
-def getMinutesCount(screenshot: GrayImage, position: BBox) -> int:
-    minutesCountsImage = convertGraysToBlack(
-        screenshot[position[1]:position[1] + 8, position[0] + 130:position[0] + 144])
-    minutesCountsHashKey = hashit(minutesCountsImage)
-    minutesCount = 0
-    if minutesCountsHashKey in minutesOrHoursHashes:
-        minutesCount = minutesOrHoursHashes[minutesCountsHashKey]
-    hoursCountsImage = convertGraysToBlack(
-        screenshot[position[1]:position[1] + 8, position[0] + 110:position[0] + 124])
-    hoursCountsHashKey = hashit(hoursCountsImage)
-    hoursCount = 0
-    if hoursCountsHashKey in minutesOrHoursHashes:
-        hoursCount = minutesOrHoursHashes[hoursCountsHashKey]
-    return (hoursCount * 60) + minutesCount
-
-
-# TODO: add unit tests
-# TODO: add perf
-def getValuesCount(screenshot: GrayImage, position: BBox) -> int:
-    capacityHundredsCountsImage = convertGraysToBlack(
-        screenshot[position[1]:position[1] + 8, position[0] + 144 - 22:position[0] + 144])
-    capacityHundredsCountsImage = np.where(
-        np.logical_or(capacityHundredsCountsImage == 126, capacityHundredsCountsImage == 192), 192, 0)
-    capacityHundredsCountsImage = np.array(
-        capacityHundredsCountsImage, dtype=np.uint8)
-    capacityHundredsCountsHashKey = hashit(capacityHundredsCountsImage)
-    capacityHundredsCount = 0
-    if capacityHundredsCountsHashKey in numbersHashes:
-        capacityHundredsCount = numbersHashes[capacityHundredsCountsHashKey]
-    capacityThousandsCountsImage = convertGraysToBlack(
-        screenshot[position[1]:position[1] + 8, position[0] + 116 - 22:position[0] + 116])
-    capacityThousandsCountsImage = np.where(
-        np.logical_or(capacityThousandsCountsImage == 126, capacityThousandsCountsImage == 192), 192, 0)
-    capacityThousandsCountsImage = np.array(
-        capacityThousandsCountsImage, dtype=np.uint8)
-    capacityThousandsCountsHashKey = hashit(
-        capacityThousandsCountsImage)
-    capacityThousandsCount = 0
-    if capacityThousandsCountsHashKey in numbersHashes:
-        capacityThousandsCount = numbersHashes[capacityThousandsCountsHashKey] * 1000
-    return capacityThousandsCount + capacityHundredsCount
+# Obsolete Python functions getMinutesCount and getValuesCount are removed.


### PR DESCRIPTION
I've migrated the core logic of skill value extraction (HP, Mana, Capacity, Speed, Food, Stamina) from `src/repositories/skills/core.py` to Rust.

The following Python functions now delegate their main processing to Rust:
- `getHp`
- `getMana`
- `getCapacity`
- `getSpeed`
- `getFood`
- `getStamina`

The Rust implementations are located in the `py_rust_utils` crate (shared library `py_rust_utils_module.so`) and include:
- FFI functions callable from Python.
- Helper functions for image region extraction, pixel processing (thresholding similar to Python's `convertGraysToBlack` and the value-specific filter), and FarmHashing.
- These Rust functions accept NumPy arrays for screenshots, skill icon bounding boxes, and pre-computed hash maps from Python.

Unit tests for the new Rust logic have been added to the `py_rust_utils` crate.

The Python module `src/repositories/skills/core.py` has been updated to:
- Import and call these new Rust functions.
- Pass the necessary data (screenshot, icon position, hash maps).
- Remove the now-obsolete Python helper functions (`getMinutesCount`, `getValuesCount`).

This change enhances performance and type safety for the critical skill detection functionality by leveraging Rust. The updated `py_rust_utils_module.so` (which now includes 8 functions in total) has been placed in `src/gameplay/`.