### PR TITLE
feat: Migrate getClosestCoordinate in coordinate.py to Rust

### DIFF
--- a/src/utils/coordinate.py
+++ b/src/utils/coordinate.py
@@ -1,8 +1,24 @@
 from numba import njit
 import numpy as np
-from scipy.spatial import distance
 from typing import List, Union
 from src.shared.typings import Coordinate, CoordinateList, XYCoordinate
+import ctypes
+from py_rust_utils import lib as py_rust_lib
+
+
+# FFI Function Signature Setup
+if hasattr(py_rust_lib, 'find_closest_coordinate_rust'):
+    py_rust_lib.find_closest_coordinate_rust.argtypes = [
+        ctypes.c_double,                        # target_x
+        ctypes.c_double,                        # target_y
+        ctypes.POINTER(ctypes.c_double),        # coords_data
+        ctypes.c_size_t                         # num_coords
+    ]
+    py_rust_lib.find_closest_coordinate_rust.restype = ctypes.c_ssize_t # index or -1
+else:
+    print("Warning: FFI function 'find_closest_coordinate_rust' not found in py_rust_lib.")
+    # Or raise an error, or set a flag to fallback if that's desired.
+    # For now, a warning is fine as per previous patterns.
 
 
 # TODO: add unit tests
@@ -39,12 +55,44 @@ def getAvailableAroundCoordinates(coordinate: Coordinate, walkableFloorSqms: np.
 
 
 def getClosestCoordinate(coordinate: Coordinate, coordinates: CoordinateList) -> Coordinate:
-    coordinateWithoutFloor = (coordinate[0], coordinate[1])
-    coordinatesWithoutFloor = [(x[0], x[1]) for x in coordinates]
-    distancesOfCoordinates = distance.cdist(
-        [coordinateWithoutFloor], coordinatesWithoutFloor)[0]
-    closestCoordinateIndex = np.argsort(distancesOfCoordinates)[0]
-    return coordinates[closestCoordinateIndex]
+    if not coordinates:
+        # Or return coordinate? Or None? Or specific error for no valid closest?
+        # For now, raising ValueError as SciPy might also error on empty inputs for cdist.
+        raise ValueError("Input 'coordinates' list cannot be empty.")
+
+    if not hasattr(py_rust_lib, 'find_closest_coordinate_rust'):
+        # Fallback to original SciPy logic or raise an error if the FFI function is missing.
+        # For this migration, we'll raise a RuntimeError as SciPy will be removed.
+        raise RuntimeError("Rust FFI function 'find_closest_coordinate_rust' is not available.")
+
+    target_x = float(coordinate[0])
+    target_y = float(coordinate[1])
+    # We ignore target_z for distance calculation as per original logic.
+
+    # Convert list of tuples to a flat NumPy array for FFI
+    # The Rust side expects [x1, y1, z1, x2, y2, z2, ...]
+    # Ensure it's float64 to match ctypes.c_double
+    coords_np = np.array(coordinates, dtype=np.float64)
+    if not coords_np.flags['C_CONTIGUOUS']:
+        coords_np = np.ascontiguousarray(coords_np, dtype=np.float64)
+    
+    coords_ptr = coords_np.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
+    num_coords = len(coordinates)
+
+    closest_idx = py_rust_lib.find_closest_coordinate_rust(
+        ctypes.c_double(target_x),
+        ctypes.c_double(target_y),
+        coords_ptr,
+        ctypes.c_size_t(num_coords)
+    )
+
+    if closest_idx < 0:
+        # Rust function indicates an error (e.g., -1 if num_coords was 0, though we check above)
+        # or some other internal issue.
+        raise RuntimeError(f"Rust function 'find_closest_coordinate_rust' returned error code: {closest_idx}")
+    
+    # closest_idx is a valid index
+    return coordinates[closest_idx]
 
 
 def getCoordinateFromPixel(pixel: XYCoordinate) -> Coordinate:


### PR DESCRIPTION
I've migrated the `getClosestCoordinate` function in `src/utils/coordinate.py` to use a Rust FFI implementation (`find_closest_coordinate_rust`) from the `py_rust_utils` shared library.

Changes in `src/utils/coordinate.py`:
- The `getClosestCoordinate` function now calls the Rust FFI function `find_closest_coordinate_rust` to find the index of the closest coordinate. This replaces the previous implementation that used `scipy.spatial.distance.cdist` and `numpy.argsort`.
- The Python function handles data preparation for FFI, including converting the list of coordinate tuples to a C-contiguous NumPy array of float64.
- I've added the FFI signature (argtypes and restype) for `find_closest_coordinate_rust`.
- I've imported `ctypes` and `py_rust_utils.lib`.
- I've removed the unused import `from scipy.spatial import distance`.

This migration aims to optimize a computationally intensive function by leveraging Rust's performance for numerical calculations and to potentially reduce reliance on SciPy.