### PR TITLE
feat: Migrate pixel processing functions in battleList/core.py to Rust

### DIFF
--- a/src/repositories/battleList/core.py
+++ b/src/repositories/battleList/core.py
@@ -1,11 +1,44 @@
+import ctypes # Added
 from numba import njit
 import numpy as np
-from typing import Generator, Union
+from typing import Generator, Union, List # Added List
 from src.shared.typings import CreatureCategory, CreatureCategoryOrUnknown, GrayImage
 from src.utils.core import hashit, locate
+from src.utils.image import RustImageData, _numpy_to_rust_image_data, py_rust_lib # Added
 from .config import creaturesNamesImagesHashes, images
 from .extractors import getCreaturesNamesImages
 from .typings import CreatureList, Creature
+
+
+# FFI Function Signature Setup 
+
+# count_filled_slots_rust
+if hasattr(py_rust_lib, 'count_filled_slots_rust'):
+    py_rust_lib.count_filled_slots_rust.argtypes = [RustImageData]
+    py_rust_lib.count_filled_slots_rust.restype = ctypes.c_int32
+else:
+    # Consistent with warnings in other modules
+    print("Warning: FFI function 'count_filled_slots_rust' not found in py_rust_lib.")
+
+# determine_being_attacked_rust
+if hasattr(py_rust_lib, 'determine_being_attacked_rust'):
+    py_rust_lib.determine_being_attacked_rust.argtypes = [
+        RustImageData,      # battle_list_content_data
+        ctypes.c_int32      # filled_slots_count
+    ]
+    py_rust_lib.determine_being_attacked_rust.restype = ctypes.POINTER(ctypes.c_bool)
+else:
+    print("Warning: FFI function 'determine_being_attacked_rust' not found in py_rust_lib.")
+
+# free_rust_bool_array
+if hasattr(py_rust_lib, 'free_rust_bool_array'):
+    py_rust_lib.free_rust_bool_array.argtypes = [
+        ctypes.POINTER(ctypes.c_bool),  # pointer to the boolean array
+        ctypes.c_size_t                 # number of elements in the array
+    ]
+    py_rust_lib.free_rust_bool_array.restype = None
+else:
+    print("Warning: FFI function 'free_rust_bool_array' not found in py_rust_lib.")
 
 
 # PERF: [0.13737060000000056, 4.999999987376214e-07]
@@ -17,24 +50,45 @@ def getBeingAttackedCreatureCategory(creatures: CreatureList) -> Union[CreatureC
     return None
 
 
-# PERF: [1.3400000000274304e-05, 2.9000000001389026e-06]
-@njit(cache=True, fastmath=True)
-def getBeingAttackedCreatures(content: GrayImage, filledSlotsCount: int) -> Generator[bool, None, None]:
-    alreadyCalculatedBeingAttackedCreature = False
-    for creatureIndex in range(filledSlotsCount):
-        contentIndex = creatureIndex * 22
-        if alreadyCalculatedBeingAttackedCreature:
-            yield False
-        else:
-            # detecting through corner pixels
-            isBeingAttacked = (content[creatureIndex * 22, 0] == 76 or content[contentIndex, 0] == 166) and (content[contentIndex, 19] == 76 or content[contentIndex, 19] == 166) and (
-                content[contentIndex + 19, 0] == 76 or content[contentIndex + 19, 0] == 166) and (content[contentIndex + 19, 19] == 76 or content[contentIndex + 19, 19] == 166)
-            yield isBeingAttacked
-            if isBeingAttacked:
-                alreadyCalculatedBeingAttackedCreature = True
+# PERF: [1.3400000000274304e-05, 2.9000000001389026e-06] # Original PERF comment
+def getBeingAttackedCreatures(content: GrayImage, filledSlotsCount: int) -> List[bool]:
+    if not hasattr(py_rust_lib, 'determine_being_attacked_rust') or \
+       not hasattr(py_rust_lib, 'free_rust_bool_array'):
+        raise RuntimeError("Rust FFI functions for getBeingAttackedCreatures are not available.")
+
+    if _numpy_to_rust_image_data is None:
+        raise RuntimeError("Helper function '_numpy_to_rust_image_data' is not available.")
+
+    if filledSlotsCount == 0:
+        return []
+
+    # Convert input GrayImage to RustImageData
+    rust_content_data = _numpy_to_rust_image_data(content, "GRAY")
+
+    # Call the FFI function
+    bool_array_ptr = py_rust_lib.determine_being_attacked_rust(
+        rust_content_data,
+        ctypes.c_int32(filledSlotsCount)
+    )
+
+    results = []
+    if bool_array_ptr:
+        try:
+            # Convert C array of booleans to Python list
+            for i in range(filledSlotsCount):
+                results.append(bool(bool_array_ptr[i]))
+        finally:
+            # Free the memory allocated by Rust
+            py_rust_lib.free_rust_bool_array(bool_array_ptr, ctypes.c_size_t(filledSlotsCount))
+    else:
+        # Handle null pointer return from Rust, e.g., allocation failure in Rust
+        # Return empty list or raise an error. For now, empty list.
+        print("Warning: determine_being_attacked_rust returned a null pointer.")
+    
+    return results
 
 
-# PERF: [0.00017040000000001498, 7.330000000038694e-05]
+# PERF: [0.00017040000000001498, 7.330000000038694e-05] # Original PERF comment
 def getCreatures(content: GrayImage) -> CreatureList:
     if content is not None:
         filledSlotsCount = getFilledSlotsCount(content)
@@ -58,26 +112,25 @@ def getCreaturesNames(content: GrayImage, filledSlotsCount: int) -> Generator[Cr
         yield creaturesNamesImagesHashes.get(hashit(creatureNameImage), 'Unknown')
 
 
-# PERF: [0.5794668999999999, 3.9999999934536845e-07]
-@njit(cache=True, fastmath=True)
+# PERF: [0.5794668999999999, 3.9999999934536845e-07] # Original PERF comment
 def getFilledSlotsCount(content: GrayImage) -> int:
-    filledSlotsCount = 0
-    for slotIndex in range(len(content) // 22):
-        y = 22 * slotIndex
-        if content[:, 23][y + 11] == 192 or content[:, 23][y + 11] == 247:
-            filledSlotsCount += 1
-        elif content[:, 23][y + 10] == 192 or content[:, 23][y + 10] == 247:
-            filledSlotsCount += 1
-        elif content[:, 23][y + 4] == 192 or content[:, 23][y + 4] == 247:
-            filledSlotsCount += 1
-        elif content[:, 23][y + 5] == 192 or content[:, 23][y + 5] == 247:
-            filledSlotsCount += 1
-        else:
-            break
-    return filledSlotsCount
+    if not hasattr(py_rust_lib, 'count_filled_slots_rust'):
+        raise RuntimeError("Rust FFI function 'count_filled_slots_rust' is not available.")
+    
+    if _numpy_to_rust_image_data is None: # Should have been imported
+        raise RuntimeError("Helper function '_numpy_to_rust_image_data' is not available.")
+
+    # Convert input GrayImage (NumPy array) to RustImageData
+    # Assuming "GRAY" format for single channel image data.
+    rust_content_data = _numpy_to_rust_image_data(content, "GRAY")
+
+    # Call the FFI function
+    count = py_rust_lib.count_filled_slots_rust(rust_content_data)
+    
+    return count
 
 
-# PERF: [7.5999999999964984e-06, 7.999999986907369e-07]
+# PERF: [7.5999999999964984e-06, 7.999999986907369e-07] # Original PERF comment
 def hasSkull(content: GrayImage, creatures: CreatureList) -> bool:
     for creatureIndex, creature in enumerate(creatures):
         if creature['name'] != 'Unknown':


### PR DESCRIPTION
I've migrated two Numba-optimized functions in `src/repositories/battleList/core.py` that involve direct pixel processing of battle list image content to use Rust FFI implementations from the `py_rust_utils` shared library.

Here are the changes I made in `src/repositories/battleList/core.py`:
- Updated `getFilledSlotsCount`:
    - Removed `@njit` decorator.
    - It now calls the Rust FFI function `count_filled_slots_rust` to count filled slots based on pixel values.
    - I've handled the conversion of the input image to `RustImageData`.
- Updated `getBeingAttackedCreatures`:
    - Removed `@njit` decorator and changed it from a generator to a function returning `List[bool]`.
    - It now calls the Rust FFI function `determine_being_attacked_rust` to get a boolean array indicating which creatures are being attacked.
    - I've handled the conversion of the input image to `RustImageData`.
    - I'm managing memory for the boolean array returned by Rust by calling a `free_rust_bool_array` FFI function.
- Added FFI signatures (argtypes and restype) for `count_filled_slots_rust`, `determine_being_attacked_rust`, and `free_rust_bool_array`.
- Imported `ctypes` and FFI helper utilities (`RustImageData`, `_numpy_to_rust_image_data`, `py_rust_lib`) from `src.utils.image`.
- The `numba` import remains as other functions in the file still use `@njit`.

This migration aims to consolidate performance-critical pixel manipulation logic within the Rust utility library.