### PR TITLE
Refactor: Decouple configuration into skb_config crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,14 @@
-workspace = { members = ["skb_modules"] }
+[workspace]
+members = ["skb_modules", "skb_rust_project/skb_config", "skb_rust_project/skb_utils"] # Added skb_utils to members
+resolver = "2"
+
 [package]
 name = "skb"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+skb_config = { path = "skb_rust_project/skb_config", version = "0.1.0" }
+skb_utils = { path = "skb_rust_project/skb_utils", version = "0.1.0" } # Added skb_utils dependency
+log = "0.4"
+env_logger = "0.10"

--- a/skb_rust_project/skb_config/Cargo.toml
+++ b/skb_rust_project/skb_config/Cargo.toml
@@ -1,0 +1,11 @@
+# skb_config/Cargo.toml
+[package]
+name = "skb_config"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+config-rs = { version = "0.13", features = ["toml"] } # Using 'config-rs' as the crate name
+thiserror = "1.0"
+log = "0.4"

--- a/skb_rust_project/skb_config/src/error.rs
+++ b/skb_rust_project/skb_config/src/error.rs
@@ -1,0 +1,16 @@
+// skb_config/src/error.rs
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("Failed to load configuration")]
+    LoadError(#[from] config_rs::ConfigError), // Using config_rs::ConfigError
+
+    #[error("I/O error reading configuration file")]
+    IoError(#[from] std::io::Error),
+
+    // Add any other specific error types if they become necessary
+    // For example, if we had specific validation errors not covered by ConfigError:
+    // #[error("Configuration validation error: {0}")]
+    // ValidationError(String),
+}

--- a/skb_rust_project/skb_config/src/lib.rs
+++ b/skb_rust_project/skb_config/src/lib.rs
@@ -1,0 +1,11 @@
+// skb_config/src/lib.rs
+pub mod error;
+pub use error::ConfigError;
+
+pub mod types;
+pub use types::Config;
+// If you had AdvancedSettings and wanted to re-export it:
+// pub use types::AdvancedSettings;
+
+pub mod loader;
+pub use loader::load_config;

--- a/skb_rust_project/skb_config/src/loader.rs
+++ b/skb_rust_project/skb_config/src/loader.rs
@@ -1,0 +1,39 @@
+// skb_config/src/loader.rs
+use crate::types::Config; // Assuming types.rs is in the same crate root
+use crate::error::ConfigError;
+use config_rs::{Config as ConfigRs, File, Environment}; // Alias config_rs::Config to ConfigRs
+use std::path::Path;
+
+pub fn load_config(config_dir_path: &Path) -> Result<Config, ConfigError> {
+    let default_config_path = config_dir_path.join("default.toml");
+    let local_config_path = config_dir_path.join("local.toml");
+    // Optional: Add other sources like environment-specific files, e.g., development.toml, production.toml
+
+    let mut builder = ConfigRs::builder()
+        // Add default values (if any are not covered by Config::default() orserde defaults)
+        // .set_default("some_key", "default_value")?
+        // This line would require ConfigError to have a variant for config_rs::ConfigError if set_default can fail
+        // For now, assuming Config::default() or TOML files provide all necessary defaults.
+
+        // Load default configuration file
+        .add_source(File::from(default_config_path).required(false)); // Make default optional for flexibility
+
+    // Load local overrides if local.toml exists
+    if local_config_path.exists() {
+        builder = builder.add_source(File::from(local_config_path).required(true));
+    }
+
+    // Add environment variables overrides
+    // Example: SKB_BOT_NAME would override config.bot_name
+    // Adjust prefix and separator as needed
+    builder = builder.add_source(Environment::with_prefix("SKB").separator("__"));
+
+    // Build the configuration
+    let settings = builder.build()?; // This will map to ConfigError::LoadError due to #[from]
+
+    // Deserialize into the Config struct
+    match settings.try_deserialize::<Config>() {
+        Ok(config) => Ok(config),
+        Err(e) => Err(ConfigError::LoadError(e)), // Ensure this mapping is correct
+    }
+}

--- a/skb_rust_project/skb_config/src/types.rs
+++ b/skb_rust_project/skb_config/src/types.rs
@@ -1,0 +1,47 @@
+// skb_config/src/types.rs
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Config {
+    // Common application settings
+    pub log_level: Option<String>, // e.g., "INFO", "DEBUG"
+    pub bot_name: Option<String>,
+
+    // Placeholder for game-related or operational settings
+    // These are GUESSES and LIKELY NEED TO BE CHANGED
+    pub game_window_title: Option<String>,
+    pub scan_interval_ms: Option<u64>,
+
+    // Example of a nested structure, if applicable
+    // pub advanced_settings: Option<AdvancedSettings>,
+}
+
+// Example of a nested struct, if you have one.
+// #[derive(Debug, Deserialize, Clone)]
+// pub struct AdvancedSettings {
+//     pub feature_flag_x: bool,
+//     pub retry_attempts: u32,
+// }
+
+// Default implementation - this will also LIKELY NEED ADJUSTMENT
+// or be removed if all fields are truly optional and loaded by config-rs
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            log_level: Some("INFO".to_string()),
+            bot_name: Some("SKBot".to_string()),
+            game_window_title: None,
+            scan_interval_ms: Some(1000),
+            // advanced_settings: Some(AdvancedSettings::default()),
+        }
+    }
+}
+
+// impl Default for AdvancedSettings {
+//     fn default() -> Self {
+//         AdvancedSettings {
+//             feature_flag_x: false,
+//             retry_attempts: 3,
+//         }
+//     }
+// }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,24 @@
+// src/error.rs
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("Configuration error")]
+    Config(#[from] skb_config::ConfigError),
+
+    #[error("Utility error: {0}")] // Modified to display the underlying error string
+    Utils(String), // Placeholder until skb_utils::error::UtilsError is defined and crate exists
+
+    // If skb_utils and its error type were defined:
+    // #[error("Utility error")]
+    // Utils(#[from] skb_utils::error::UtilsError),
+
+    #[error("I/O error")]
+    Io(#[from] std::io::Error),
+
+    #[error("Logger setup failed")]
+    Logging(#[from] log::SetLoggerError),
+
+    #[error("Application runtime error: {0}")]
+    Runtime(String), // Generic runtime error
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,64 @@
-fn main() {
-    println!("Hello, world!");
+// src/main.rs
+
+mod error; // Declare error module
+use error::AppError; // Use AppError
+
+use skb_config::{load_config, Config as SkbAppConfig};
+use std::path::Path;
+
+// This path will likely need to be verified by the user.
+const CONTROL_CONFIG_DIR_PATH: &str = "config";
+
+// Placeholder for skb_utils::logging::setup_logging
+// This function would typically live in the skb_utils crate.
+// For now, we define a local placeholder to make the main.rs logic clearer.
+// In a real setup, this would be: use skb_utils::logging::setup_logging;
+// env_logger::try_init returns Result<(), log::SetLoggerError>
+fn setup_logging_placeholder(log_level: Option<&str>) -> Result<(), log::SetLoggerError> {
+    let level = log_level.unwrap_or("info");
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(level)).try_init()?;
+    Ok(())
+}
+
+
+fn main() -> Result<(), AppError> {
+    // Load configuration
+    // The '?' operator will convert skb_config::ConfigError into AppError::Config
+    // due to the #[from] attribute in AppError's definition.
+    let config = load_config(Path::new(CONTROL_CONFIG_DIR_PATH))?;
+
+    // Setup logging
+    // The '?' operator will convert log::SetLoggerError into AppError::Logging
+    // due to the #[from] attribute in AppError's definition for Logging.
+    setup_logging_placeholder(config.log_level.as_deref())?;
+
+    log::info!("SKB Control starting...");
+    log::debug!("Configuration loaded: {:?}", config);
+
+    // Placeholder for the main bot loop
+    if let Err(e) = run_bot_loop(&config) {
+        log::error!("Error in bot loop: {}", e);
+        return Err(e); // run_bot_loop now returns AppError
+    }
+
+    log::info!("SKB Control finished successfully.");
+    Ok(())
+}
+
+fn run_bot_loop(config: &SkbAppConfig) -> Result<(), AppError> {
+    log::info!("Bot loop starting.");
+    log::debug!("Using scan_interval_ms: {:?}", config.scan_interval_ms);
+
+    // ... existing or new bot logic based on config ...
+    // Example: if config.bot_name.as_deref().unwrap_or("").contains("TestBot") { log::info!("TestBot specific logic here.") }
+
+    // Simulate a potential runtime error
+    if config.bot_name.as_deref().unwrap_or("") == "ErrorBot" {
+        return Err(AppError::Runtime("Simulated error from ErrorBot configuration".to_string()));
+    }
+
+    println!("Bot loop executed. (Placeholder - implement actual bot logic here)");
+
+    log::info!("Bot loop finished.");
+    Ok(())
 }


### PR DESCRIPTION
This commit introduces a new dedicated crate `skb_config` for managing application configuration, following the Mfe3O architectural design. The main application ("skb") has been refactored to use this new crate.

Key changes:

1.  **New Crate `skb_config`**:
    *   Created `skb_rust_project/skb_config` as a library crate.
    *   Added to workspace members.
    *   Dependencies: `serde`, `config-rs`, `thiserror`, `log`.
    *   Defines `ConfigError` enum in `skb_config::error`.
    *   Defines a placeholder `Config` struct in `skb_config::types`.
      (You'll need to update the fields to match your application's needs).
    *   Implements `load_config(config_dir_path: &Path)` in
      `skb_config::loader` to load settings from TOML files (default, local)
      and environment variables.

2.  **Main Application ("skb" - in `src/main.rs`) Refactoring**:
    *   Added `skb_config` as a dependency.
    *   `src/main.rs` now calls `skb_config::load_config` to load settings.
      (You'll need to verify `CONTROL_CONFIG_DIR_PATH` in `main.rs`).
    *   Removed previous configuration loading logic (conceptually, as
      the old `app_config.rs` was not found/accessible by me).
    *   Introduced `src/error.rs` with a new `AppError` enum for robust
      error handling in the main application.
    *   `main()` and `run_bot_loop()` now return `Result<(), AppError>`.
    *   Added `skb_utils` as a dependency to `Cargo.toml` and workspace,
      and `AppError` includes a placeholder for `skb_utils::error::UtilsError`,
      in preparation for future `skb_utils` implementation.
    *   Logging initialization (`env_logger`) is now in `main.rs`, using
      a placeholder for `skb_utils::logging::setup_logging`.

This refactoring enhances modularity by separating configuration concerns, making the system more maintainable and aligned with the intended architecture.