### PR TITLE
Feature: Add skb_action_bar crate for action bar state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ members = [
     "skb_rust_project/skb_utils",
     "skb_rust_project/skb_input",
     "skb_rust_project/skb_game_state",
-    "skb_rust_project/skb_gameplay_logic"
+    "skb_rust_project/skb_gameplay_logic",
+    "skb_rust_project/skb_action_bar"
 ]
 resolver = "2"
 

--- a/skb_rust_project/skb_action_bar/Cargo.toml
+++ b/skb_rust_project/skb_action_bar/Cargo.toml
@@ -1,0 +1,11 @@
+# skb_action_bar/Cargo.toml
+[package]
+name = "skb_action_bar"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+thiserror = "1.0"
+# skb_input = { path = "../skb_input", optional = true } # If manager calls input
+# skb_config = { path = "../skb_config", optional = true } # For layout/config
+# serde = { version = "1.0", features = ["derive"], optional = true }

--- a/skb_rust_project/skb_action_bar/src/error.rs
+++ b/skb_rust_project/skb_action_bar/src/error.rs
@@ -1,0 +1,42 @@
+//! Defines the error types for the `skb_action_bar` crate.
+
+use thiserror::Error;
+
+/// Represents errors that can occur during action bar operations or state management.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum ActionBarError {
+    /// Indicates that an action slot with the specified identifier was not found.
+    /// The string argument is typically the `slot_key_designator`.
+    #[error("Action slot with ID '{0}' not found.")]
+    SlotNotFound(String),
+
+    /// Signifies an attempt to perform an invalid action or assign invalid content
+    /// to a specified action slot.
+    #[error("Invalid action or content for slot '{slot_id}': {reason}")]
+    InvalidSlotAction {
+        /// The identifier of the slot where the invalid action was attempted.
+        slot_id: String,
+        /// The reason why the action or content was considered invalid.
+        reason: String,
+    },
+
+    /// Denotes an error related to the configuration of the action bar itself
+    /// (e.g., invalid layout data, misconfigured slot definitions).
+    #[error("Configuration error related to action bar: {0}")]
+    ConfigurationError(String),
+
+    /// Occurs when a perception module fails to update the action bar's state
+    /// or provides inconsistent or unparseable data.
+    #[error("Perception module failed to update action bar state: {0}")]
+    PerceptionError(String),
+
+    // If this crate were to also handle input via skb_input:
+    // #[error("Input action failed for slot '{slot_id}'")]
+    // InputActionFailed {
+    //     slot_id: String,
+    //     #[source] // Optional: if skb_input::InputError is to be wrapped directly
+    //     source_error: skb_input::InputError, // Requires skb_input as a dependency
+    // },
+
+    // Add other specific error types as they become necessary.
+}

--- a/skb_rust_project/skb_action_bar/src/lib.rs
+++ b/skb_rust_project/skb_action_bar/src/lib.rs
@@ -1,0 +1,145 @@
+//! `skb_action_bar` - A Rust crate for representing and managing the state of in-game action bars.
+//!
+//! This crate provides data structures to hold information about individual action slots,
+//! their content (which can be spells or items), cooldown status, and other relevant details.
+//! The [`ActionBarManager`] struct is the primary interface for updating and querying the
+//! collective state of all monitored action bar slots.
+//!
+//! This crate is intended to be used by perception modules (which would update the state
+//! based on screen analysis) and by gameplay logic modules (which would query the state
+//! to make decisions, such as whether a spell can be cast or an item used).
+//!
+//! # Main Components
+//! - [`ActionBarManager`]: The central manager for storing and providing access to action bar state.
+//! - [`ActionSlot`]: Represents a single slot on an action bar, including its content and status.
+//! - [`SlotContentType`]: An enum describing what a slot contains (e.g., `Empty`, `Spell`, `Item`).
+//! - [`ActionBarError`]: Defines errors specific to action bar operations within this crate.
+//!
+//! # Basic Usage
+//! ```
+//! use skb_action_bar::{ActionBarManager, ActionSlot, SlotContentType, ActionBarError};
+//!
+//! fn main() -> Result<(), ActionBarError> { // Using ActionBarError for example simplicity
+//!     let mut manager = ActionBarManager::new();
+//!
+//!     // Simulate an update from a perception module
+//!     let slot_f1_data = ActionSlot {
+//!         slot_key_designator: "F1".to_string(),
+//!         content: SlotContentType::Spell { spell_id: "Fireball".to_string() },
+//!         is_on_cooldown: false,
+//!         cooldown_remaining_ms: None,
+//!         is_active: Some(false),
+//!         last_observed_image_hash: Some("hash123".to_string()),
+//!     };
+//!     manager.update_slot(slot_f1_data);
+//!
+//!     // Gameplay logic queries the manager
+//!     if let Some(slot) = manager.get_slot("F1") {
+//!         if !slot.is_on_cooldown {
+//!             if let SlotContentType::Spell { spell_id } = &slot.content {
+//!                 println!("Slot F1 contains spell '{}' and it's ready!", spell_id);
+//!                 // Gameplay logic might decide to use "Fireball"
+//!             }
+//!         }
+//!     }
+//!
+//!     // Check cooldown for a specific spell
+//!     match manager.is_spell_on_cooldown("Fireball") {
+//!         Some(true) => println!("Fireball is on cooldown."),
+//!         Some(false) => println!("Fireball is ready."),
+//!         None => println!("Fireball spell not found on action bar."),
+//!     }
+//!     Ok(())
+//! }
+//! ```
+
+pub mod error;
+pub use error::ActionBarError;
+
+pub mod types;
+pub use types::{ActionSlot, ActionBarState, SlotContentType};
+
+pub mod manager;
+pub use manager::ActionBarManager;
+
+// TODO: FFI Exposure (PyO3)
+// The `ActionBarManager` and its associated data types (`ActionSlot`, `ActionBarState`,
+// `SlotContentType`) may need to be exposed to Python. This would allow Python code
+// (e.g., UI, scripting layer, or main bot orchestrator) to:
+//  - Read the current state of the action bar.
+//  - Potentially receive updates or subscribe to changes (more advanced).
+//  - (Less likely for this crate, but possible) Trigger updates to the action bar state
+//    if some state is determined or configured from Python.
+//
+// This would likely involve:
+// 1. Adding `pyo3` to Cargo.toml dependencies (with `macros` feature for this crate).
+// 2. Making `ActionSlot`, `ActionBarState`, `SlotContentType` (and its inner data if any)
+//    `#[pyclass]`es. This requires them to be `Clone` (which they are).
+//    - For enums like `SlotContentType`, specific handling for PyO3 might be needed
+//      (e.g., converting to/from Python strings or dicts, or making the enum itself a `#[pyclass]`).
+// 3. Creating a `#[pyclass]` wrapper for `ActionBarManager`, perhaps named `PyActionBarManager`.
+//    - This wrapper would likely hold an `Arc<RwLock<ActionBarManager>>` to allow shared,
+//      mutable access from Python if methods modify the state (our current manager methods take `&mut self`).
+//      If only read access is needed from Python, `Arc<ActionBarManager>` might suffice if manager methods become `&self`.
+//    - Exposing methods like `get_slot_py`, `get_all_slots_py`, `is_spell_on_cooldown_py` via `#[pymethods]`.
+//      These would need to handle conversion of Rust types to Python types (e.g., `Vec<ActionSlot>` to `PyList`).
+// 4. Error Handling: `ActionBarError` would need to be converted to appropriate Python exceptions.
+// 5. Defining a PyO3 module (e.g., `skb_action_bar_py`) to register these classes.
+//
+// Example (conceptual for exposing ActionBarManager for reading):
+/*
+use pyo3::prelude::*;
+use std::sync::Arc;
+use parking_lot::RwLock; // Or std::sync::RwLock
+
+// Assume ActionSlot, SlotContentType are also #[pyclass]
+// use crate::types::{ActionSlot as RustActionSlot, SlotContentType as RustSlotContentType};
+
+
+#[pyclass(name = "ActionBarManager")]
+struct PyActionBarManager {
+    // ActionBarManager methods take &mut self, so it needs to be behind a RwLock/Mutex
+    // for shared access from Python.
+    manager: Arc<RwLock<ActionBarManager>>,
+}
+
+#[pymethods]
+impl PyActionBarManager {
+    #[new]
+    fn new() -> Self {
+        PyActionBarManager {
+            manager: Arc::new(RwLock::new(ActionBarManager::new())),
+        }
+    }
+
+    fn get_slot_py(&self, slot_key_designator: String) -> PyResult<Option<ActionSlot>> {
+        let manager = self.manager.read(); // Or .lock() for Mutex
+        // .cloned() is important as we can't hold a reference across FFI boundary easily
+        // if the ActionSlot is not a PyClass itself that Python can own.
+        // If ActionSlot is a PyClass, we might return it directly.
+        Ok(manager.get_slot(&slot_key_designator).cloned())
+    }
+
+    fn get_all_slots_py(&self, py: Python) -> PyResult<PyObject> {
+        let manager = self.manager.read();
+        // Convert Vec<ActionSlot> to a Python list of PyActionSlot objects
+        let py_slots = manager.get_all_slots().iter().map(|slot| {
+            // Assuming ActionSlot has a #[pyclass] and can be converted to Py<ActionSlot>
+            // Py::new(py, slot.clone()).unwrap().into_py(py)
+            // For simplicity, if ActionSlot is not a PyClass directly passed:
+            format!("{:?}", slot) // Or convert to PyDict
+        }).collect::<Vec<_>>();
+        Ok(pyo3::types::PyList::new(py, &py_slots).into())
+    }
+
+    // Add other methods like is_spell_on_cooldown_py, etc.
+}
+
+#[pymodule]
+fn skb_action_bar_py(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<PyActionBarManager>()?;
+    m.add_class::<ActionSlot>()?; // If ActionSlot is made a PyClass
+    m.add_class::<SlotContentType>()?; // If SlotContentType is made a PyClass (or handled differently)
+    Ok(())
+}
+*/

--- a/skb_rust_project/skb_action_bar/src/manager.rs
+++ b/skb_rust_project/skb_action_bar/src/manager.rs
@@ -1,0 +1,295 @@
+//! Provides the `ActionBarManager` for managing the state of action bar(s)
+//! based on perceived information from the game.
+
+use crate::types::{ActionBarState, ActionSlot, SlotContentType};
+use crate::error::ActionBarError; // Keep even if not directly returned by public methods, for consistency or future use.
+use std::collections::HashMap;
+
+// For timestamping, similar to skb_game_state
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Manages the collective state of all observed action bar slots.
+///
+/// This struct allows updating slot information (typically from perception modules based on screen observation)
+/// and querying the current state of these slots (which can be used by gameplay logic modules
+/// to make decisions, e.g., checking if a spell is on cooldown or an item is available).
+/// It uses a `HashMap` internally for efficient lookup of slots by their string identifiers.
+#[derive(Debug, Clone, Default)]
+pub struct ActionBarManager {
+    state: ActionBarState,
+    // Optional: For quick lookup of slot index by its key designator
+    slot_index_map: HashMap<String, usize>,
+}
+
+impl ActionBarManager {
+    /// Creates a new, empty `ActionBarManager`.
+    /// The internal state is initialized to default values, meaning no slots are present
+    /// and the `last_update_timestamp_ms` is `None`.
+    pub fn new() -> Self {
+        Self::default() // Relies on derive(Default) for both ActionBarManager and ActionBarState
+    }
+
+    /// Adds a new action slot or updates an existing one based on `slot_key_designator`.
+    ///
+    /// If a slot with the same `slot_key_designator` as `new_slot_data` already exists,
+    /// its data is replaced with `new_slot_data`. Otherwise, `new_slot_data` is added
+    /// to the manager's list of slots.
+    /// The internal `slot_index_map` is updated accordingly for quick lookups.
+    /// The manager's `last_update_timestamp_ms` (on the internal `ActionBarState`) is updated.
+    ///
+    /// # Arguments
+    /// * `new_slot_data`: The `ActionSlot` data to add or update.
+    pub fn update_slot(&mut self, new_slot_data: ActionSlot) {
+        let key = new_slot_data.slot_key_designator.clone();
+        if let Some(index) = self.slot_index_map.get(&key) {
+            if let Some(slot) = self.state.slots.get_mut(*index) {
+                *slot = new_slot_data;
+            }
+        } else {
+            let new_index = self.state.slots.len();
+            self.state.slots.push(new_slot_data);
+            self.slot_index_map.insert(key, new_index);
+        }
+        self.update_timestamp();
+    }
+
+    /// Replaces all currently managed action slots with a new set of slots.
+    ///
+    /// This is useful for performing a full refresh of the action bar state,
+    /// for example, when perception modules provide a complete new snapshot.
+    /// The internal `slot_index_map` is rebuilt, and the `last_update_timestamp_ms` is updated.
+    ///
+    /// # Arguments
+    /// * `all_slots`: A `Vec<ActionSlot>` containing the new set of action slots.
+    pub fn replace_all_slots(&mut self, all_slots: Vec<ActionSlot>) {
+        self.state.slots = all_slots;
+        self.rebuild_slot_index_map();
+        self.update_timestamp();
+    }
+
+    /// Helper to rebuild the `slot_index_map` for efficient lookups.
+    /// This should be called whenever `state.slots` is entirely replaced or significantly restructured.
+    fn rebuild_slot_index_map(&mut self) {
+        self.slot_index_map.clear();
+        for (index, slot) in self.state.slots.iter().enumerate() {
+            self.slot_index_map.insert(slot.slot_key_designator.clone(), index);
+        }
+    }
+
+    /// Retrieves a read-only reference to a specific action slot by its key designator.
+    ///
+    /// # Arguments
+    /// * `slot_key_designator`: The unique string identifier of the slot to retrieve.
+    ///
+    /// # Returns
+    /// Returns `Some(&ActionSlot)` if a slot with the given designator is found,
+    /// otherwise returns `None`.
+    pub fn get_slot(&self, slot_key_designator: &str) -> Option<&ActionSlot> {
+        self.slot_index_map.get(slot_key_designator)
+            .and_then(|index| self.state.slots.get(*index))
+    }
+
+    /// Retrieves a read-only reference to the vector of all currently monitored action slots.
+    pub fn get_all_slots(&self) -> &Vec<ActionSlot> {
+        &self.state.slots
+    }
+
+    /// Checks if a specific spell is currently observed to be on cooldown.
+    ///
+    /// This method iterates through all managed action slots. If a slot containing
+    /// a spell with the given `spell_id_to_check` is found, its `is_on_cooldown`
+    /// status is returned.
+    ///
+    /// # Arguments
+    /// * `spell_id_to_check`: The unique identifier (e.g., name or game ID) of the spell.
+    ///
+    /// # Returns
+    /// - `Some(true)` if the spell is found in a slot and `is_on_cooldown` is true.
+    /// - `Some(false)` if the spell is found in a slot and `is_on_cooldown` is false.
+    /// - `None` if no slot contains a spell with the specified ID.
+    pub fn is_spell_on_cooldown(&self, spell_id_to_check: &str) -> Option<bool> {
+        for slot in &self.state.slots {
+            if let SlotContentType::Spell { spell_id } = &slot.content {
+                if spell_id == spell_id_to_check {
+                    return Some(slot.is_on_cooldown);
+                }
+            }
+        }
+        None // Spell not found
+    }
+
+    /// Finds the first action slot containing an item with the specified item ID.
+    ///
+    /// This method iterates through all managed action slots. If a slot containing
+    /// an item with the given `item_id_to_find` is found, a reference to that
+    /// `ActionSlot` is returned.
+    ///
+    /// # Arguments
+    /// * `item_id_to_find`: The unique identifier (e.g., name or game ID) of the item.
+    ///
+    /// # Returns
+    /// Returns `Some(&ActionSlot)` if an item with the specified ID is found in any slot,
+    /// otherwise returns `None`. If multiple slots contain the item, only the first one
+    /// encountered during iteration is returned.
+    pub fn find_item_in_slots(&self, item_id_to_find: &str) -> Option<&ActionSlot> {
+        self.state.slots.iter().find(|slot| {
+            if let SlotContentType::Item { item_id, .. } = &slot.content {
+                item_id == item_id_to_find
+            } else {
+                false
+            }
+        })
+    }
+
+    /// Helper to update the `last_update_timestamp_ms` of the internal `ActionBarState`.
+    ///
+    /// On non-wasm32 targets, this sets the timestamp to the current system time
+    /// in milliseconds since the UNIX epoch.
+    /// On wasm32 targets, this currently sets the timestamp to `None` as a placeholder,
+    /// indicating that a platform-specific time source might be needed for wasm if precise
+    /// update times are critical in that environment.
+    fn update_timestamp(&mut self) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.state.last_update_timestamp_ms = Some(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64,
+            );
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            // Placeholder for wasm-compatible time source or leave None
+            self.state.last_update_timestamp_ms = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*; // Imports ActionBarManager
+    use crate::types::{ActionSlot, SlotContentType}; // Import types from the same crate
+
+    #[test]
+    fn test_new_action_bar_manager() {
+        let manager = ActionBarManager::new();
+        assert!(manager.get_all_slots().is_empty(), "New manager should have no slots");
+        assert!(manager.slot_index_map.is_empty(), "New manager slot_index_map should be empty");
+        // Timestamp is None by default from ActionBarState's Default derive.
+        assert!(manager.state.last_update_timestamp_ms.is_none(), "Timestamp should be None for new manager");
+    }
+
+    #[test]
+    fn test_update_and_get_slot() {
+        let mut manager = ActionBarManager::new();
+        let slot_f1 = ActionSlot {
+            slot_key_designator: "F1".to_string(),
+            content: SlotContentType::Spell { spell_id: "heal_light".to_string() },
+            is_on_cooldown: false,
+            ..Default::default()
+        };
+        manager.update_slot(slot_f1.clone());
+
+        assert_eq!(manager.get_all_slots().len(), 1);
+        assert_eq!(manager.get_slot("F1"), Some(&slot_f1));
+        assert_eq!(manager.slot_index_map.get("F1"), Some(&0));
+
+        #[cfg(not(target_arch = "wasm32"))]
+        assert!(manager.state.last_update_timestamp_ms.is_some());
+        #[cfg(target_arch = "wasm32")]
+        assert!(manager.state.last_update_timestamp_ms.is_none());
+
+
+        // Update existing slot
+        let slot_f1_updated = ActionSlot {
+            slot_key_designator: "F1".to_string(),
+            content: SlotContentType::Spell { spell_id: "heal_greater".to_string() },
+            is_on_cooldown: true,
+            cooldown_remaining_ms: Some(5000),
+            ..Default::default()
+        };
+        manager.update_slot(slot_f1_updated.clone());
+
+        assert_eq!(manager.get_all_slots().len(), 1, "Slot count should remain 1 after update");
+        assert_eq!(manager.get_slot("F1"), Some(&slot_f1_updated));
+        assert!(manager.get_slot("F1").unwrap().is_on_cooldown);
+    }
+
+    #[test]
+    fn test_replace_all_slots() {
+        let mut manager = ActionBarManager::new();
+        manager.update_slot(ActionSlot { slot_key_designator: "F1".to_string(), ..Default::default() });
+
+        let new_slots = vec![
+            ActionSlot { slot_key_designator: "1".to_string(), content: SlotContentType::Item { item_id: "mana_potion".to_string(), quantity: 5 }, ..Default::default()},
+            ActionSlot { slot_key_designator: "2".to_string(), content: SlotContentType::Spell { spell_id: "attack_spell".to_string() }, ..Default::default()},
+        ];
+        manager.replace_all_slots(new_slots.clone());
+
+        assert_eq!(manager.get_all_slots().len(), 2);
+        assert_eq!(manager.get_slot("1"), Some(&new_slots[0]));
+        assert_eq!(manager.get_slot("2"), Some(&new_slots[1]));
+        assert!(manager.get_slot("F1").is_none(), "Old F1 slot should be gone");
+        assert_eq!(manager.slot_index_map.len(), 2);
+        assert_eq!(manager.slot_index_map.get("1"), Some(&0));
+        assert_eq!(manager.slot_index_map.get("2"), Some(&1));
+    }
+
+    #[test]
+    fn test_get_non_existent_slot() {
+        let manager = ActionBarManager::new();
+        assert!(manager.get_slot("DoesNotExist").is_none());
+    }
+
+    #[test]
+    fn test_is_spell_on_cooldown() {
+        let mut manager = ActionBarManager::new();
+        let heal_spell = ActionSlot {
+            slot_key_designator: "F1".to_string(),
+            content: SlotContentType::Spell { spell_id: "heal_light".to_string() },
+            is_on_cooldown: true,
+            cooldown_remaining_ms: Some(3000),
+            ..Default::default()
+        };
+        let attack_spell = ActionSlot {
+            slot_key_designator: "F2".to_string(),
+            content: SlotContentType::Spell { spell_id: "fireball".to_string() },
+            is_on_cooldown: false,
+            ..Default::default()
+        };
+        let item_slot = ActionSlot {
+            slot_key_designator: "1".to_string(),
+            content: SlotContentType::Item { item_id: "potion".to_string(), quantity: 1 },
+            ..Default::default()
+        };
+        manager.replace_all_slots(vec![heal_spell, attack_spell, item_slot]);
+
+        assert_eq!(manager.is_spell_on_cooldown("heal_light"), Some(true));
+        assert_eq!(manager.is_spell_on_cooldown("fireball"), Some(false));
+        assert_eq!(manager.is_spell_on_cooldown("unknown_spell"), None);
+    }
+
+    #[test]
+    fn test_find_item_in_slots() {
+        let mut manager = ActionBarManager::new();
+        let potion_slot_data = ActionSlot {
+            slot_key_designator: "1".to_string(),
+            content: SlotContentType::Item { item_id: "health_potion".to_string(), quantity: 5 },
+            ..Default::default()
+        };
+        let spell_slot_data = ActionSlot {
+            slot_key_designator: "F1".to_string(),
+            content: SlotContentType::Spell { spell_id: "heal".to_string() },
+            ..Default::default()
+        };
+         manager.replace_all_slots(vec![potion_slot_data.clone(), spell_slot_data]);
+
+        let found_item_slot = manager.find_item_in_slots("health_potion");
+        assert_eq!(found_item_slot, Some(&potion_slot_data));
+
+        let not_found_item = manager.find_item_in_slots("mana_potion");
+        assert!(not_found_item.is_none());
+    }
+}

--- a/skb_rust_project/skb_action_bar/src/types.rs
+++ b/skb_rust_project/skb_action_bar/src/types.rs
@@ -1,0 +1,74 @@
+//! Contains all core data structures and enums for representing the state of game action bars
+//! and their individual slots.
+
+// Potentially use serde later if these need to be serialized (e.g. from config or for logging).
+// use serde::{Serialize, Deserialize};
+
+/// Describes the content of an action slot, which can be empty, a spell, or an item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+// #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum SlotContentType {
+    /// The slot is currently empty.
+    Empty,
+    /// The slot contains a spell.
+    Spell {
+        /// A unique identifier for the spell (e.g., its name or an internal game ID).
+        spell_id: String,
+    },
+    /// The slot contains an item.
+    Item {
+        /// A unique identifier for the item type (e.g., its name or an internal game ID).
+        item_id: String,
+        /// The quantity of the item in this slot, if stackable.
+        quantity: u32,
+    },
+}
+
+impl Default for SlotContentType {
+    /// Returns `SlotContentType::Empty` as the default content type.
+    fn default() -> Self {
+        SlotContentType::Empty
+    }
+}
+
+/// Represents the dynamic state of a single action slot on the action bar.
+/// This information is typically gathered by perception modules.
+#[derive(Debug, Clone, PartialEq, Default)]
+// #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ActionSlot {
+    /// A string identifying the slot, e.g., "F1", "1", "MainBar_Slot3".
+    /// This should match a configured slot designator used for consistent identification.
+    pub slot_key_designator: String,
+
+    /// The observed content of the slot (e.g., empty, a specific spell, or an item).
+    pub content: SlotContentType,
+
+    /// Whether the action or item in the slot is currently on cooldown.
+    pub is_on_cooldown: bool,
+
+    /// Estimated remaining cooldown time in milliseconds, if known and currently on cooldown.
+    /// `None` if not on cooldown or if the remaining time is unknown.
+    pub cooldown_remaining_ms: Option<u32>,
+
+    /// For abilities or spells that can be toggled on/off, this indicates if it's currently active.
+    /// `None` if the content is not toggleable or if its active state is unknown.
+    pub is_active: Option<bool>,
+
+    /// An optional hash of the slot's last observed image or visual representation.
+    /// This can be used by perception modules to quickly detect if a slot's visual appearance
+    /// has changed, potentially triggering a more detailed analysis of its state.
+    pub last_observed_image_hash: Option<String>,
+}
+
+/// Represents the overall observed state of all monitored action slots on one or more action bars.
+#[derive(Debug, Clone, PartialEq, Default)]
+// #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ActionBarState {
+    /// A list of the current states of all known or monitored action slots.
+    /// The order might be significant if it reflects a specific action bar layout.
+    pub slots: Vec<ActionSlot>,
+
+    /// Timestamp of the last update to any slot in this state, in milliseconds since UNIX epoch.
+    /// Can be used to determine the freshness of the action bar information.
+    pub last_update_timestamp_ms: Option<u64>,
+}


### PR DESCRIPTION
This commit introduces the new `skb_action_bar` crate, designed to represent and manage the state of in-game action bars. This crate will allow me to understand the contents and status (e.g., cooldowns) of action slots.

Key features and structure:

1.  **Crate Setup (`skb_rust_project/skb_action_bar`)**:
    *   Initialized as a library crate and added to the workspace.
    *   Core dependency: `thiserror`. Optional dependencies for `skb_input`,
      `skb_config`, and `serde` are noted for future use.

2.  **Error Handling (`src/error.rs`)**:
    *   Defines `ActionBarError` enum with variants for issues like
      `SlotNotFound`, `InvalidSlotAction`, `ConfigurationError`, and
      `PerceptionError`.

3.  **Core Data Structures (`src/types.rs`)**:
    *   `SlotContentType` enum: Represents `Empty`, `Spell { spell_id }`,
      or `Item { item_id, quantity }`.
    *   `ActionSlot` struct: Details a single slot including its
      `slot_key_designator`, `content`, `is_on_cooldown`,
      `cooldown_remaining_ms`, `is_active`, and
      `last_observed_image_hash`.
    *   `ActionBarState` struct: Holds a `Vec<ActionSlot>` and a
      `last_update_timestamp_ms`.

4.  **State Management (`src/manager.rs`)**:
    *   `ActionBarManager` struct: Manages `ActionBarState` internally,
      using a `HashMap` for efficient lookup of slots by their
      `slot_key_designator`.
    *   Provides methods to `update_slot`, `replace_all_slots`,
      `get_slot`, `get_all_slots`.
    *   Includes logic to query specific states like
      `is_spell_on_cooldown` and `find_item_in_slots`.
    *   Handles timestamping of state updates with wasm32 considerations.

5.  **Testing (`#[cfg(test)]` in `src/manager.rs`)**:
    *   Unit tests cover `ActionBarManager`'s constructor, update methods
      (add, update, replace), query methods, and specific logic like
      cooldown checks and item finding.

6.  **Documentation**:
    *   Comprehensive Rustdoc comments added for all public items,
      including errors, data structures, fields, methods, and a
      crate-level overview with a usage example.

7.  **FFI Placeholder**:
    *   A TODO comment in `lib.rs` outlines future PyO3 FFI exposure for
      Python integration.

This crate provides the structural foundation for understanding and interacting with game action bars, which will be essential for more intelligent gameplay logic. The actual population of `ActionBarState` will depend on future perception modules.